### PR TITLE
Remove current warning about checkedsum 

### DIFF
--- a/src/constants/tokens/rinkeby.ts
+++ b/src/constants/tokens/rinkeby.ts
@@ -17,7 +17,7 @@ export default [
   ),
   new Token(
     ChainId.RINKEBY,
-    "0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b",
+    "0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b",
     6,
     "USDC",
     "USDC",


### PR DESCRIPTION
Closes #49 

The address string was all in lowercase, so the solution for this is to put the correct address or use https://web3js.readthedocs.io/en/v1.2.11/web3-utils.html#tochecksumaddress , I go for the first solution of course, easy and more simple.
We can check the contract here https://rinkeby.etherscan.io/address/0x4dbcdf9b62e891a7cec5a2568c3f4faf9e8abe2b