### PR TITLE
Changing contract to newest version, supporting allowLists

### DIFF
--- a/src/constants/abis/easyAuction/easyAuction.json
+++ b/src/constants/abis/easyAuction/easyAuction.json
@@ -153,6 +153,12 @@
         "internalType": "uint256",
         "name": "minFundingThreshold",
         "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "allowListManager",
+        "type": "address"
       }
     ],
     "name": "NewAuction",
@@ -254,6 +260,25 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "auctionAccessManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -537,6 +562,11 @@
         "internalType": "bool",
         "name": "isAtomicClosureAllowed",
         "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "allowListManager",
+        "type": "address"
       }
     ],
     "name": "initiateAuction",
@@ -597,6 +627,11 @@
         "internalType": "bytes32[]",
         "name": "_prevSellOrders",
         "type": "bytes32[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "allowListCallData",
+        "type": "bytes"
       }
     ],
     "name": "placeSellOrders",
@@ -712,6 +747,11 @@
         "internalType": "bytes32[]",
         "name": "_prevSellOrder",
         "type": "bytes32[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "allowListCallData",
+        "type": "bytes"
       }
     ],
     "name": "settleAuctionAtomically",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,7 +12,7 @@ export const EASY_AUCTION_NETWORKS: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441",
   [ChainId.ROPSTEN]: "0x53C43764255c17BD724F74c4eF150724AC50a3ed",
   [ChainId.KOVAN]: "0x2cc8688C5f75E365aaEEb4ea8D6a480405A48D2A",
-  [ChainId.RINKEBY]: "0xdC5f67d34aB3489b5bfD34645B7271615FAcdfA2",
+  [ChainId.RINKEBY]: "0x99e63218201e44549AB8a6Fa220e1018FDB48f79",
   [ChainId.GÖRLI]: "0x732ed4E98f7906B81eb8ECD5269952DCEd966A0f",
 };
 // used for display in the default list when adding liquidity

--- a/src/hooks/usePlaceOrderCallback.ts
+++ b/src/hooks/usePlaceOrderCallback.ts
@@ -88,6 +88,7 @@ export function usePlaceOrderCallback(
           [buyAmountScaled.toString()],
           [sellAmountScaled.toString()],
           [previousOrder],
+          "0x",
         ];
         value = null;
       }


### PR DESCRIPTION
This PR updates the contracts to the newest smart contracts.

The new contracts are basically the same + allowListing participation. When placing orders, in a future version of the front-end, the user can also send a signature from the auctioneer that they are allowed to participate in the auction.

But for now, let's not focus on that part - we will simply always send "0x" when placing an order.


testplan:
take the lastest commit from ido-services, and run:
```
cargo run --bin orderbook
```

and then start this app with:
```
yarn start
```
check that data is corrrectly loaded