### PR TITLE
addingg .env back

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+REACT_APP_CHAIN_ID=4
+REACT_APP_NETWORK_URL=https://rinkey.infura.io/v3/4bf032f2d38a4ed6bb975b80d6340847
+REACT_APP_ADDITIONAL_SERVICES_API_URL=https://ido-v1-api-rinkeby.dev.gnosisdev.com/

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,3 @@ package-lock.json
 cypress/videos
 cypress/screenshots
 cypress/fixtures/example.json
-
-.env


### PR DESCRIPTION
Actually, not having .env file also brought down our [own dev-env website](https://ido-ux.dev.gnosisdev.com/#/auction). 

Since we would like to get them back on, I have this small fix.

But, we can come up with a cleaner way for dealing with env variables, for sure. Any input welcome @mariano-aguero 

Though,  I kinda like to have my own setup as .env.local and having a default .env always available.