### PR TITLE
If the user changes the metamask account, the orders should be reseted

### DIFF
--- a/src/components/Web3ReactManager/index.tsx
+++ b/src/components/Web3ReactManager/index.tsx
@@ -4,7 +4,11 @@ import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 
 import { network } from "../../connectors";
-import { useEagerConnect, useInactiveListener } from "../../hooks";
+import {
+  useEagerConnect,
+  useInactiveListener,
+  useActiveListener,
+} from "../../hooks";
 import { Spinner } from "../../theme";
 import Circle from "../../assets/images/circle.svg";
 import { NetworkContextName } from "../../constants";
@@ -51,6 +55,9 @@ export default function Web3ReactManager({ children }) {
 
   // when there's no account connected, react to logins (broadly speaking) on the injected provider, if it exists
   useInactiveListener(!triedEager);
+
+  // So we can trigger some events on accountsChanged
+  useActiveListener();
 
   // handle delayed loader state
   const [showLoader, setShowLoader] = useState(false);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { isMobile } from "react-device-detect";
 import { injected } from "../connectors";
 import { NetworkContextName } from "../constants";
+import { useOrderActionHandlers } from "../state/orders/hooks";
 
 export function useActiveWeb3React() {
   const context = useWeb3ReactCore<Web3Provider>();
@@ -91,4 +92,25 @@ export function useInactiveListener(suppress = false) {
     }
     return;
   }, [active, error, suppress, activate]);
+}
+
+/**
+ * Hook that subscribes to some events
+ */
+export function useActiveListener() {
+  const { active, error, activate } = useWeb3ReactCore();
+  const { onReloadFromAPI } = useOrderActionHandlers();
+
+  useEffect(() => {
+    const { ethereum } = window;
+
+    if (ethereum && ethereum.on && active && !error) {
+      const handleAccountsChanged = () => {
+        // Reload orders on accounts changed
+        onReloadFromAPI();
+      };
+
+      ethereum.on("accountsChanged", handleAccountsChanged);
+    }
+  }, [active, error, onReloadFromAPI, activate]);
 }


### PR DESCRIPTION
Closes #43 

We subscribe to the account change event of the ethereum object, and then we trigger the update of the orders to solve the problem.