### PR TITLE
Fix division by zero

### DIFF
--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -476,6 +476,7 @@ export function useCurrentUserOrders() {
 
           // in some of the orders the buyAmount field is zero
           if (order.buyAmount.isZero()) {
+            console.error(`Order buyAmount shouldn't be zero`)
             continue
           }
 


### PR DESCRIPTION
Closes #109 

In some of the  orders the buyAmount field is null zero, that generates a division by zero