### PR TITLE
Price should be displayed correctly, if decimals are not 18

### DIFF
--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -11,6 +11,7 @@ import {
   useDerivedAuctionState,
 } from '../../../state/orderPlacement/hooks'
 import { getEtherscanLink, getTokenDisplay } from '../../../utils'
+import { normalizePrice } from '../../../utils/tools'
 import TokenLogo from '../../TokenLogo'
 import { KeyValue } from '../../common/KeyValue'
 import { Tooltip } from '../../common/Tooltip'
@@ -82,8 +83,12 @@ const AuctionDetails = () => {
       orderToSellOrder(clearingPriceInfo.clearingOrder, biddingToken, auctioningToken)
     let clearingPriceNumber = orderToPrice(clearingPriceInfoAsSellOrder)?.toSignificant(4)
 
-    if (clearingPrice) {
-      clearingPriceNumber = clearingPrice && clearingPrice.toSignificant(4)
+    if (clearingPrice && auctioningToken && biddingToken) {
+      clearingPriceNumber = normalizePrice(
+        auctioningToken,
+        biddingToken,
+        clearingPrice,
+      ).toSignificant(4)
     }
 
     return clearingPriceNumber
@@ -103,6 +108,14 @@ const AuctionDetails = () => {
         : 'Closing price',
     [auctionState],
   )
+
+  const initialPriceToDisplay = useMemo(() => {
+    if (initialPrice && auctioningToken && biddingToken) {
+      return normalizePrice(auctioningToken, biddingToken, initialPrice)
+    } else {
+      return initialPrice
+    }
+  }, [initialPrice, auctioningToken, biddingToken])
 
   return (
     <Wrapper noPadding>
@@ -174,10 +187,12 @@ const AuctionDetails = () => {
           </>
         }
         itemValue={
-          initialPrice && auctioningTokenDisplay && auctioningTokenDisplay
-            ? `${initialPrice ? initialPrice?.toSignificant(2) : ' - '}
-          ${biddingTokenDisplay}/${auctioningTokenDisplay}`
-            : '-'
+          <>
+            {initialPriceToDisplay ? initialPriceToDisplay?.toSignificant(2) : ' - '}
+            {initialPriceToDisplay && auctioningTokenDisplay
+              ? `${biddingTokenDisplay}/${auctioningTokenDisplay}`
+              : '-'}
+          </>
         }
       />
     </Wrapper>

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,3 +1,7 @@
+import { Fraction, Token } from 'uniswap-xdai-sdk'
+
+import { BigNumber } from '@ethersproject/bignumber'
+
 export const truncateStringInTheMiddle = (
   str: string,
   strPositionStart: number,
@@ -51,4 +55,14 @@ export const calculateTimeProgress = (auctionStartDate: number, auctionEndDate: 
       : Math.trunc((passedTime * 100) / totalTime)
 
   return isNaN(auctionStartDate) || isNaN(auctionEndDate) ? `0%` : `${percentage}%`
+}
+
+export const normalizePrice = (auctioningToken: Token, biddingToken: Token, price: Fraction) => {
+  if (auctioningToken.decimals === 18 && biddingToken.decimals === 18) {
+    return price
+  }
+  const decimals =
+    auctioningToken.decimals !== 18 ? auctioningToken.decimals : biddingToken.decimals
+  const fixedPoint = BigNumber.from(10).pow(decimals).toString()
+  return price?.multiply(fixedPoint)
 }


### PR DESCRIPTION
Closes #128 

An example: 
![Screenshot_20210305_151330](https://user-images.githubusercontent.com/1144028/110156154-5ef3d700-7dc5-11eb-9f09-bf97e87787d5.png)
8 decimals https://rinkeby.etherscan.io/token/0x64ed1291fe07ade7bb261c7aa8491e4bc0e8de1c