### PR TITLE
Add improvement for order cancelation

### DIFF
--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -268,6 +268,7 @@ export function useDerivedAuctionInfo(): {
   clearingPriceVolume: BigNumber | undefined
   initialPrice: Fraction | undefined
   minBiddingAmountPerOrder: string | undefined
+  orderCancellationEndDate: number | undefined
 } {
   const { account } = useActiveWeb3React()
 
@@ -329,6 +330,7 @@ export function useDerivedAuctionInfo(): {
     clearingPriceVolume,
     initialPrice,
     minBiddingAmountPerOrder,
+    orderCancellationEndDate: auctionDetails?.orderCancellationEndDate,
   }
 }
 


### PR DESCRIPTION
No issue related...

The order placement should only be possible before the time given in the variable: orderCancellationEndDate from the api, for example: 
```
https://ido-v1-api-rinkeby.dev.gnosisdev.com/api/v1/get_auction_with_details/4
```
If its possible to place orders after that, the contract will always revert and we should prevent it in the first place