### PR TITLE
Removing Cookies and About and Privacy License

### DIFF
--- a/src/components/layout/Footer/index.tsx
+++ b/src/components/layout/Footer/index.tsx
@@ -108,16 +108,10 @@ export const Footer: React.FC<Props> = (props) => {
           <Link to="/terms-and-conditions#topAnchor">Terms</Link>
         </Item>
         <Item>
-          <Link to="/privacy-policy#topAnchor">Privacy</Link>
-        </Item>
-        <Item>
           <Link to="/cookie-policy#topAnchor">Cookies</Link>
           <IconWrapper onClick={onCookiesBannerShow}>
             <SettingsIconStyled />
           </IconWrapper>
-        </Item>
-        <Item>
-          <Link to="/licenses#topAnchor">Licenses</Link>
         </Item>
         <Item>
           <Link to="/imprint#topAnchor">Imprint</Link>

--- a/src/components/navigation/sections.tsx
+++ b/src/components/navigation/sections.tsx
@@ -9,10 +9,6 @@ export const navItems = [
     icon: <SendIcon />,
   },
   {
-    title: 'About',
-    url: '/about#topAnchor',
-  },
-  {
     title: 'Docs',
     url: '/docs#topAnchor',
   },

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -12,15 +12,12 @@ import { MainScroll } from '../components/pureStyledComponents/MainScroll'
 import { MainWrapper } from '../components/pureStyledComponents/MainWrapper'
 import { PUBLIC_URL } from '../constants/config'
 import DarkModeQueryParamReader from '../theme/DarkModeQueryParamReader'
-import { About } from './About'
 import Auction from './Auction'
-import { Cookies } from './Cookies'
 import { Documentation } from './Documentation'
 import { Imprint } from './Imprint'
 import { Landing } from './Landing'
 import { Licenses } from './Licenses'
 import Overview from './Overview'
-import { Privacy } from './Privacy'
 import { Terms } from './Terms'
 
 let Router: React.ComponentType
@@ -49,10 +46,7 @@ export default function App() {
                   <Route component={Overview} exact path="/overview" strict />
                   <Route component={Landing} exact path="/start" strict />
                   <Route component={Terms} exact path="/terms-and-conditions" strict />
-                  <Route component={Privacy} exact path="/privacy-policy" strict />
-                  <Route component={Cookies} exact path="/cookie-policy" strict />
                   <Route component={Licenses} exact path="/licenses" strict />
-                  <Route component={About} exact path="/about" strict />
                   <Route component={Imprint} exact path="/imprint" strict />
                   <Route component={Documentation} exact path="/docs" strict />
                   <Route component={Documentation} exact path="/docs/batch-auctions" strict />


### PR DESCRIPTION
If we don't have any cookies and store any user data, then we don't need a privacy license, cookies. 
I think it's wise to remove all storing of data and don't bring in another legal complication.

Please highlight the points, where we are storing actual user data and where we could get in conflict with a non-existing privacy policy.


Also, this PR removes the `About` link on the landing page, as the landing page and docs provide suffiicent information.
