### PR TITLE
Allows to reset orders

### DIFF
--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -508,7 +508,7 @@ export function useCurrentUserOrders() {
   const { account } = useActiveWeb3React()
   const { auctionId, chainId } = useSwapState()
   const derivedAuctionInfo = useDerivedAuctionInfo()
-  const { onNewOrder } = useOrderActionHandlers()
+  const { onResetOrder } = useOrderActionHandlers()
 
   useEffect(() => {
     let cancelled = false
@@ -561,7 +561,7 @@ export function useCurrentUserOrders() {
           status: OrderStatus.PLACED,
         })
       }
-      if (!cancelled) onNewOrder(sellOrderDisplays)
+      if (!cancelled) onResetOrder(sellOrderDisplays)
     }
     fetchData()
     return (): void => {
@@ -571,7 +571,7 @@ export function useCurrentUserOrders() {
     chainId,
     account,
     auctionId,
-    onNewOrder,
+    onResetOrder,
     derivedAuctionInfo?.auctioningToken,
     derivedAuctionInfo?.biddingToken,
   ])

--- a/src/state/orderbook/actions.ts
+++ b/src/state/orderbook/actions.ts
@@ -13,7 +13,7 @@ export const removeBid = createAction<{
 export const resetOrderbookData = createAction<{
   orderbook: OrderBookData
   error: Maybe<Error>
-}>('ResetOrders')
+}>('ResetOrderbookOrders')
 
 export const pullOrderbookData = createAction<void>('PullOrderbookData')
 

--- a/src/state/orders/actions.ts
+++ b/src/state/orders/actions.ts
@@ -6,6 +6,10 @@ export const appendOrders = createAction<{
   orders: OrderDisplay[]
 }>('AppendOrders')
 
+export const resetOrders = createAction<{
+  orders: OrderDisplay[]
+}>('ResetOrders')
+
 export const removeOrders = createAction<{
   orderId: string
 }>('RemoveOrders')

--- a/src/state/orders/hooks.ts
+++ b/src/state/orders/hooks.ts
@@ -3,7 +3,13 @@ import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { AppDispatch, AppState } from '..'
-import { appendOrders, finalizeOrderPlacement, loadOrderFromAPI, removeOrders } from './actions'
+import {
+  appendOrders,
+  finalizeOrderPlacement,
+  loadOrderFromAPI,
+  removeOrders,
+  resetOrders,
+} from './actions'
 import { OrderDisplay } from './reducer'
 
 export function useOrderState(): AppState['orders'] {
@@ -11,6 +17,7 @@ export function useOrderState(): AppState['orders'] {
 }
 
 export function useOrderActionHandlers(): {
+  onResetOrder: (orders: OrderDisplay[]) => void
   onNewOrder: (orders: OrderDisplay[]) => void
   onDeleteOrder: (orderId: string) => void
   onFinalizeOrder: () => void
@@ -21,6 +28,12 @@ export function useOrderActionHandlers(): {
   const onNewOrder = useCallback(
     (orders: OrderDisplay[]) => {
       dispatch(appendOrders({ orders }))
+    },
+    [dispatch],
+  )
+  const onResetOrder = useCallback(
+    (orders: OrderDisplay[]) => {
+      dispatch(resetOrders({ orders }))
     },
     [dispatch],
   )
@@ -39,5 +52,5 @@ export function useOrderActionHandlers(): {
     [dispatch],
   )
 
-  return { onNewOrder, onReloadFromAPI, onFinalizeOrder, onDeleteOrder }
+  return { onResetOrder, onNewOrder, onReloadFromAPI, onFinalizeOrder, onDeleteOrder }
 }

--- a/src/state/orders/reducer.ts
+++ b/src/state/orders/reducer.ts
@@ -1,6 +1,12 @@
 import { createReducer } from '@reduxjs/toolkit'
 
-import { appendOrders, finalizeOrderPlacement, loadOrderFromAPI, removeOrders } from './actions'
+import {
+  appendOrders,
+  finalizeOrderPlacement,
+  loadOrderFromAPI,
+  removeOrders,
+  resetOrders,
+} from './actions'
 
 export enum OrderStatus {
   PENDING,
@@ -15,12 +21,10 @@ export interface OrderDisplay {
 }
 export interface OrderState {
   orders: OrderDisplay[]
-  shouldLoad: boolean
 }
 
 const initialState: OrderState = {
   orders: [],
-  shouldLoad: true,
 }
 
 export default createReducer<OrderState>(initialState, (builder) =>
@@ -31,7 +35,13 @@ export default createReducer<OrderState>(initialState, (builder) =>
       return {
         ...state,
         orders,
-        shouldLoad: false,
+      }
+    })
+    .addCase(resetOrders, (state: OrderState, { payload: { orders } }) => {
+      orders = [...new Set(orders)]
+      return {
+        ...state,
+        orders,
       }
     })
     .addCase(removeOrders, (state: OrderState, { payload: { orderId } }) => {
@@ -54,14 +64,12 @@ export default createReducer<OrderState>(initialState, (builder) =>
       return {
         ...state,
         orders,
-        shouldLoad: false,
       }
     })
     .addCase(loadOrderFromAPI, (state: OrderState) => {
       return {
         ...state,
         orders: [],
-        shouldLoad: true,
       }
     }),
 )


### PR DESCRIPTION
Previously, orders have only. been appended and this results in: 
#198 

Now, this Pr enables to reset them properly.

While the loading is still buggy and flashy, at least eventually, it shows the right order data. This loading performance will be addressed in another PR.