### PR TITLE
[Easy] removes About section

### DIFF
--- a/src/components/navigation/sections.tsx
+++ b/src/components/navigation/sections.tsx
@@ -9,10 +9,6 @@ export const navItems = [
     icon: <SendIcon />,
   },
   {
-    title: 'About',
-    url: '/about#topAnchor',
-  },
-  {
     title: 'Docs',
     url: '/docs#topAnchor',
   },


### PR DESCRIPTION
About is no longer needed...

I left the about component, such that we can re-enable it easily, if it is later needed