### PR TITLE
(fix) show info message only if the user is connected

### DIFF
--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -145,7 +145,7 @@ const Claimer: React.FC<ClaimerProps> = (props) => {
           </Text>
         </TokenItem>
       </TokensWrapper>
-      {!isValid && (
+      {!isValid && account && (
         <ErrorWrapper>
           <ErrorRow>
             <ErrorInfo />


### PR DESCRIPTION
Closes #222 

The message should be now shown only if the user is connected.

_However_, take into account that you are only disconnected if you purposely click on the "Disconnect" button. That way you'll see the message disappear... otherwise, the app will automatically connect to your wallet every time you open it (odd, I know).

