### PR TITLE
Custom decimals for abbreviation function

### DIFF
--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -383,6 +383,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
         pendingConfirmation={pendingConfirmation}
         pendingText={pendingText}
         title="Confirm Order"
+        width={504}
       />
     </>
   )

--- a/src/components/modals/common/PlaceOrderModalFooter/index.tsx
+++ b/src/components/modals/common/PlaceOrderModalFooter/index.tsx
@@ -92,7 +92,7 @@ const SwapModalFooter: React.FC<Props> = (props) => {
       <Row>
         <Text>{biddingTokenDisplay} Tokens sold</Text>
         <Value>
-          <Text>{abbreviation(sellAmount)}</Text>
+          <Text>{abbreviation(sellAmount, 10)}</Text>
           <div>
             <TokenLogo
               size="24px"
@@ -104,7 +104,7 @@ const SwapModalFooter: React.FC<Props> = (props) => {
       <Row>
         <Text>Minimum {auctioningTokenDisplay} received</Text>
         <Value>
-          <Text>{abbreviation(minimumReceived?.toSignificant(2))}</Text>
+          <Text>{abbreviation(minimumReceived?.toSignificant(2), 10)}</Text>
           <div>
             <TokenLogo
               size="24px"
@@ -118,7 +118,7 @@ const SwapModalFooter: React.FC<Props> = (props) => {
           Max {biddingTokenDisplay} paid per {auctioningTokenDisplay}
         </Text>
         <Value>
-          <Text>{abbreviation(price)}</Text>
+          <Text>{abbreviation(price, 10)}</Text>
           <div>
             <DoubleLogo
               auctioningToken={{ address: auctioningToken.address, symbol: auctioningToken.symbol }}

--- a/src/utils/numeral.ts
+++ b/src/utils/numeral.ts
@@ -1,6 +1,6 @@
 import numbro from 'numbro'
 
-export const abbreviation = (_value: string | number) => {
+export const abbreviation = (_value: string | number, mantissa = 6) => {
   const value = Number(_value)
 
   if (!isNaN(value)) {
@@ -12,7 +12,7 @@ export const abbreviation = (_value: string | number) => {
       optionalMantissa: true,
       trimMantissa: true,
       average: false,
-      mantissa: 6,
+      mantissa,
     }
 
     // If the value is greater than 9999, it will be short. For example: 10000 => 10k or 1000000 => 1m


### PR DESCRIPTION
Confirm Order Modal now allows **10 decimal**.

<img width="551" alt="Screen Shot 2021-03-26 at 8 51 17 AM" src="https://user-images.githubusercontent.com/3802516/112627976-11411c00-8e11-11eb-8f6c-83e10d15072a.png">

<img width="1043" alt="Screen Shot 2021-03-26 at 8 53 28 AM" src="https://user-images.githubusercontent.com/3802516/112628074-2cac2700-8e11-11eb-98d9-5fdc3c4879af.png">
