### PR TITLE
Shows the correct claim amounts

### DIFF
--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -120,7 +120,7 @@ const Claimer: React.FC<ClaimerProps> = (props) => {
             )}
           </Token>
           <Text>
-            {claimableBiddingToken ? `${claimableBiddingToken.toSignificant(2)} ` : `0.00`}
+            {claimableBiddingToken ? `${claimableBiddingToken.toSignificant(6)} ` : `0.00`}
           </Text>
         </TokenItem>
         <TokenItem>
@@ -141,7 +141,7 @@ const Claimer: React.FC<ClaimerProps> = (props) => {
             )}
           </Token>
           <Text>
-            {claimableAuctioningToken ? `${claimableAuctioningToken.toSignificant(2)}` : `0.00`}
+            {claimableAuctioningToken ? `${claimableAuctioningToken.toSignificant(6)}` : `0.00`}
           </Text>
         </TokenItem>
       </TokensWrapper>

--- a/src/hooks/useClaimOrderCallback.ts
+++ b/src/hooks/useClaimOrderCallback.ts
@@ -97,7 +97,7 @@ export function useGetAuctionProceeds(
   let claimableBiddingToken = new TokenAmount(derivedAuctionInfo?.biddingToken, '0')
   for (const order of claimInfo.sellOrdersFormUser) {
     const decodedOrder = decodeOrder(order)
-    if (decodedOrder == derivedAuctionInfo?.clearingPriceOrder) {
+    if (JSON.stringify(decodedOrder) == JSON.stringify(derivedAuctionInfo?.clearingPriceOrder)) {
       claimableBiddingToken = claimableBiddingToken.add(
         new TokenAmount(
           derivedAuctionInfo?.biddingToken,


### PR DESCRIPTION
closes: #257

I tested it with several auctions and now it seems to work every time and shows the correct amounts.
@elena-zh please revisit all your auction from the issue and confirm that now the claim amounts are correct.

Thanks @mariano-aguero for the deepEqual tip.

One example of a fractionally filled order:
![image](https://user-images.githubusercontent.com/7348154/112877706-60b07200-90c7-11eb-8f2b-edef449f482f.png)
