### PR TITLE
Adding additional point to display the orderbook until the end

### DIFF
--- a/src/components/auction/OrderbookWidget/index.tsx
+++ b/src/components/auction/OrderbookWidget/index.tsx
@@ -83,18 +83,22 @@ const processData = (
     pricePoints.sort((lhs, rhs) => -1 * (lhs.price - rhs.price))
 
     pricePoints.push({
-      price: (highestValue * 101) / 100,
+      price: (highestValue * 104) / 100,
       volume: 0,
     })
 
     pricePoints.sort((lhs, rhs) => -1 * (lhs.price - rhs.price))
+    pricePoints.push({
+      price: (lowestValue * 96) / 100,
+      volume: 0,
+    })
   } else {
     pricePoints.push({
-      price: (highestValue * 101) / 100,
+      price: (highestValue * 104) / 100,
       volume: 0,
     })
     pricePoints.push({
-      price: (pricePoints[0].price * 99) / 100,
+      price: (pricePoints[0].price * 96) / 100,
       volume: 0,
     })
     pricePoints.sort((lhs, rhs) => lhs.price - rhs.price)


### PR DESCRIPTION
closes #283

I tried out different values and actually, I like it better if the line does not go until the end of the chart.

Here is one of the auction that was previously not nicely displayed: 
![image](https://user-images.githubusercontent.com/7348154/112880416-b3d7f400-90ca-11eb-849b-358b4105411f.png)


If we wanna display the green line until the end, all we need to change is: 
```
  // Reduce the min in a 5%
  priceAxis.min = min - min * 0.05
```