### PR TITLE
remove the 2nd warning message about order cancellation date from the Place order section

### DIFF
--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -336,15 +336,6 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
                     </ErrorText>
                   </ErrorRow>
                 )}
-                {cancelDate && (
-                  <ErrorRow>
-                    <ErrorLock />
-                    <ErrorText>
-                      Beware: after <strong>{cancelDate}</strong> and until the end of the auction,
-                      orders cannot be canceled.
-                    </ErrorText>
-                  </ErrorRow>
-                )}
               </ErrorWrapper>
             )}
             {notApproved && (


### PR DESCRIPTION
Closes #358 

The warning is displayed in the modal