### PR TITLE
Make search of pending more specific

### DIFF
--- a/src/components/modals/TransactionsModal/index.tsx
+++ b/src/components/modals/TransactionsModal/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useAllTransactions } from '../../../state/transactions/hooks'
+import { isTransactionRecent, useAllTransactions } from '../../../state/transactions/hooks'
 import { TransactionDetails } from '../../../state/transactions/reducer'
 import Transaction from '../../common/Transaction'
 import { InfoIcon } from '../../icons/InfoIcon'
@@ -23,13 +23,9 @@ export const TransactionsModal: React.FC<Props> = (props) => {
     return b.addedTime - a.addedTime
   }
 
-  const recentTransactionsOnly = (a: TransactionDetails) => {
-    return new Date().getTime() - a.addedTime < 86_400_000
-  }
-
   const sortedRecentTransactions = React.useMemo(() => {
     const txs = Object.values(allTransactions)
-    return txs.filter(recentTransactionsOnly).sort(newTranscationsFirst)
+    return txs.filter(isTransactionRecent).sort(newTranscationsFirst)
   }, [allTransactions])
 
   const pending = sortedRecentTransactions.filter((tx) => !tx.receipt).map((tx) => tx.hash)

--- a/src/hooks/useApproveCallback.ts
+++ b/src/hooks/useApproveCallback.ts
@@ -32,7 +32,7 @@ export function useApproveCallback(
     account ?? undefined,
     addressToApprove,
   )
-  const pendingApproval = useHasPendingApproval(amountToApprove?.token?.address)
+  const pendingApproval = useHasPendingApproval(amountToApprove?.token?.address, addressToApprove)
 
   // check the current approval status
   const approval = useMemo(() => {
@@ -81,7 +81,7 @@ export function useApproveCallback(
       .then((response: TransactionResponse) => {
         addTransaction(response, {
           summary: 'Approve ' + amountToApprove?.token?.symbol,
-          approvalOfToken: amountToApprove?.token?.address,
+          approval: { tokenAddress: amountToApprove?.token?.address, spender: addressToApprove },
         })
       })
       .catch((error: Error) => {

--- a/src/state/transactions/actions.ts
+++ b/src/state/transactions/actions.ts
@@ -15,7 +15,7 @@ export const addTransaction = createAction<{
   chainId: number
   hash: string
   from: string
-  approvalOfToken?: string
+  approval?: { tokenAddress: string; spender: string }
   summary?: string
 }>('addTransaction')
 export const clearAllTransactions = createAction<{ chainId: number }>('clearAllTransactions')

--- a/src/state/transactions/reducer.ts
+++ b/src/state/transactions/reducer.ts
@@ -11,7 +11,7 @@ const now = () => new Date().getTime()
 
 export interface TransactionDetails {
   hash: string
-  approvalOfToken?: string
+  approval?: { tokenAddress: string; spender: string }
   summary?: string
   receipt?: SerializableTransactionReceipt
   addedTime: number
@@ -32,22 +32,19 @@ const initialState: TransactionState = {}
 
 export default createReducer(initialState, (builder) =>
   builder
-    .addCase(
-      addTransaction,
-      (state, { payload: { approvalOfToken, chainId, from, hash, summary } }) => {
-        if (state[chainId]?.[hash]) {
-          throw Error('Attempted to add existing transaction.')
-        }
-        state[chainId] = state[chainId] ?? {}
-        state[chainId][hash] = {
-          hash,
-          approvalOfToken,
-          summary,
-          from,
-          addedTime: now(),
-        }
-      },
-    )
+    .addCase(addTransaction, (state, { payload: { approval, chainId, from, hash, summary } }) => {
+      if (state[chainId]?.[hash]) {
+        throw Error('Attempted to add existing transaction.')
+      }
+      state[chainId] = state[chainId] ?? {}
+      state[chainId][hash] = {
+        hash,
+        approval,
+        summary,
+        from,
+        addedTime: now(),
+      }
+    })
     .addCase(clearAllTransactions, (state, { payload: { chainId } }) => {
       if (!state[chainId]) return
       state[chainId] = {}


### PR DESCRIPTION
Closes #369 

This is an idea taken from the original repository, seems like when a stuck tx is found `useHasPendingApproval` returns true (this also returns false when the amount is not specified), I'm not completely sure that this was the problem in mainnet but being more common to have stuck tx in mainnet I would give a try to this approach.