### PR TITLE
Chart bug - The orange order, the new one is no longer shown

### DIFF
--- a/src/components/auction/Charts/XYChart.ts
+++ b/src/components/auction/Charts/XYChart.ts
@@ -64,8 +64,6 @@ export const XYChart = (props: XYChartProps): am4charts.XYChart => {
   priceAxis.strictMinMax = true
   priceAxis.extraMin = 0.02
   priceAxis.extraMax = 0.02
-  priceAxis.renderer.grid.template.disabled = true
-  priceAxis.renderer.labels.template.disabled = true
 
   // Create serie, green line shows the price (x axis) and size (y axis) of the bids that have been placed, both expressed in the bid token
   const bidSeries = chart.series.push(new am4charts.StepLineSeries())
@@ -157,7 +155,7 @@ interface DrawInformation {
 }
 
 export const drawInformation = (props: DrawInformation) => {
-  const { baseToken, chart, data, quoteToken } = props
+  const { baseToken, chart, quoteToken } = props
   const baseTokenLabel = baseToken.symbol
   const quoteTokenLabel = quoteToken.symbol
   const market = quoteTokenLabel + '-' + baseTokenLabel
@@ -175,32 +173,4 @@ export const drawInformation = (props: DrawInformation) => {
 
   series.values[0].tooltipText = `[bold]${market}[/]\nAsk Price: [bold]{priceFormatted}[/] ${quoteTokenLabel}\nVolume: [bold]{totalVolumeFormatted}[/] ${quoteTokenLabel}`
   series.values[1].tooltipText = `[bold]${market}[/]\nBid Price: [bold]{priceFormatted}[/] ${quoteTokenLabel}\nVolume: [bold]{totalVolumeFormatted}[/] ${quoteTokenLabel}`
-
-  const min = Math.min.apply(
-    0,
-    data.map((order) => order.priceNumber),
-  )
-
-  const max = Math.max.apply(
-    0,
-    data.map((order) => order.priceNumber),
-  )
-
-  const createGrid = (value) => {
-    const range = xAxis.axisRanges.create() as any
-    range.value = value
-    range.label.text = '{value}'
-  }
-
-  const factor = (max - min) / 5
-
-  const firstGrid = min + factor
-  const secondGrid = min + factor * 2
-  const thirdGrid = min + factor * 3
-  const fourGrid = min + factor * 4
-
-  createGrid(firstGrid.toFixed(2))
-  createGrid(secondGrid.toFixed(2))
-  createGrid(thirdGrid.toFixed(2))
-  createGrid(fourGrid.toFixed(2))
 }

--- a/src/components/auction/Charts/XYChart.ts
+++ b/src/components/auction/Charts/XYChart.ts
@@ -80,13 +80,12 @@ export const XYChart = (props: XYChartProps): am4charts.XYChart => {
   }
 
   // Create serie, red line, shows the minimum sell price (x axis) the auctioneer is willing to accept
-  const askSeries = chart.series.push(new am4charts.StepLineSeries())
+  const askSeries = chart.series.push(new am4charts.LineSeries())
   askSeries.dataFields.valueX = 'priceNumber'
   askSeries.dataFields.valueY = 'askValueY'
   askSeries.strokeWidth = 1
   askSeries.stroke = am4core.color(colors.red)
   askSeries.fill = askSeries.stroke
-  askSeries.startLocation = 0.5
   askSeries.fillOpacity = 0.1
   askSeries.dummyData = {
     description: 'Shows the minimum sell price (x axis) the auctioneer is willing to accept',

--- a/src/components/auction/OrderbookChart/index.tsx
+++ b/src/components/auction/OrderbookChart/index.tsx
@@ -5,7 +5,7 @@ import { Token } from 'uniswap-xdai-sdk'
 import useChart from '../../../hooks/useChart'
 import { InlineLoading } from '../../common/InlineLoading'
 import { SpinnerSize } from '../../common/Spinner'
-import XYChart from '../Charts/XYChart'
+import { XYChart } from '../Charts/XYChart'
 
 export enum Offer {
   Bid,
@@ -82,7 +82,7 @@ const Wrapper = styled.div`
 const OrderBookChart: React.FC<OrderBookChartProps> = (props: OrderBookChartProps) => {
   const { baseToken, data, quoteToken } = props
 
-  const { elemRef, loading } = useChart({
+  const { loading, mountPoint } = useChart({
     createChart: XYChart,
     data,
     baseToken,
@@ -91,8 +91,8 @@ const OrderBookChart: React.FC<OrderBookChartProps> = (props: OrderBookChartProp
 
   return (
     <>
-      {(!elemRef || loading) && <InlineLoading size={SpinnerSize.small} />}
-      {elemRef && !loading && <Wrapper ref={elemRef} />}
+      {(!mountPoint || loading) && <InlineLoading size={SpinnerSize.small} />}
+      {mountPoint && !loading && <Wrapper ref={mountPoint} />}
     </>
   )
 }

--- a/src/components/auction/OrderbookWidget/index.tsx
+++ b/src/components/auction/OrderbookWidget/index.tsx
@@ -140,8 +140,8 @@ const processData = (
         // Data for representation
         priceNumber: price,
         totalVolumeNumber: totalVolume,
-        priceFormatted: price.toString(),
-        totalVolumeFormatted: totalVolume.toString(),
+        priceFormatted: price.toFixed(2),
+        totalVolumeFormatted: totalVolume.toFixed(2),
         askValueY,
         bidValueY,
         newOrderValueY: null,
@@ -162,8 +162,8 @@ const processData = (
           // Data for representation
           priceNumber: price,
           totalVolumeNumber: acc.totalVolume + volume,
-          priceFormatted: price.toString(),
-          totalVolumeFormatted: (acc.totalVolume + volume).toString(),
+          priceFormatted: price.toFixed(2),
+          totalVolumeFormatted: (acc.totalVolume + volume).toFixed(2),
           askValueY: (acc.totalVolume + volume) * price,
           bidValueY,
           newOrderValueY: null,

--- a/src/hooks/useChart.ts
+++ b/src/hooks/useChart.ts
@@ -18,6 +18,10 @@ const useChart = (props: Props) => {
 
   const [loading, setLoading] = useState(false)
 
+  // Using refs allows us to combine React with some libraries,
+  // It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
+  // Also useRef doesn’t notify you when its content changes.
+  // Mutating the .current property doesn’t cause a re-render. So is good if you need to access or update another state  at specific times
   const mountPoint = useRef<Maybe<HTMLDivElement>>(null)
   const chartRef = useRef<Maybe<am4charts.XYChart>>(null)
 

--- a/src/hooks/useChart.ts
+++ b/src/hooks/useChart.ts
@@ -1,46 +1,59 @@
 import { useEffect, useRef, useState } from 'react'
 import { Token } from 'uniswap-xdai-sdk'
 
-import * as am4core from '@amcharts/amcharts4/core'
-import am4themesSpiritedaway from '@amcharts/amcharts4/themes/spiritedaway'
+import * as am4charts from '@amcharts/amcharts4/charts'
 
+import { XYChartProps, drawInformation } from '../components/auction/Charts/XYChart'
 import { PricePointDetails } from '../components/auction/OrderbookChart'
 
-am4core.useTheme(am4themesSpiritedaway)
-
-const useChart = ({
-  baseToken,
-  createChart,
-  data,
-  quoteToken,
-}: {
-  createChart: any
+interface Props {
+  createChart: (props: XYChartProps) => am4charts.XYChart
   data: Maybe<PricePointDetails[]>
   baseToken: Token
   quoteToken: Token
-}) => {
-  const [chart, setChart] = useState(null)
-  const elemRef = useRef(null)
+}
+
+const useChart = (props: Props) => {
+  const { baseToken, createChart, data, quoteToken } = props
+
   const [loading, setLoading] = useState(false)
 
+  const mountPoint = useRef<Maybe<HTMLDivElement>>(null)
+  const chartRef = useRef<Maybe<am4charts.XYChart>>(null)
+
   useEffect(() => {
-    if (!chart) {
-      setLoading(true)
-      const currentChart = createChart({ div: elemRef.current, data, baseToken, quoteToken })
+    if (!mountPoint.current) return
+    setLoading(true)
+    const chart = createChart({
+      chartElement: mountPoint.current,
+    })
 
-      setChart(currentChart)
-      setLoading(false)
+    chartRef.current = chart
 
-      return () => {
-        if (chart) {
-          chart.dispose()
-        }
-      }
+    setLoading(false)
+    // dispose on mount only
+    return (): void => chart.dispose()
+  }, [createChart])
+
+  useEffect(() => {
+    if (!chartRef.current || data === null) return
+
+    if (data.length === 0) {
+      chartRef.current.data = []
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, baseToken, quoteToken, createChart])
 
-  return { chart, elemRef, loading }
+    drawInformation({
+      chart: chartRef.current,
+      baseToken,
+      quoteToken,
+      data,
+    })
+
+    chartRef.current.data = data
+  }, [baseToken, quoteToken, data])
+
+  return { chartRef, mountPoint, loading }
 }
 
 export default useChart


### PR DESCRIPTION
Closes #301 

Also:
closes #228 (see last comment here)
closes #224 
closes #258 
closes #217 

I removed the gridlines added manually, because breaks the chart in some cases

Look like this ...

![Screenshot_20210401_004316](https://user-images.githubusercontent.com/1144028/113240563-59ce5e80-9283-11eb-8c1a-c67fbea7ea3e.png)
