### PR TITLE
Showing price instead of min price

### DIFF
--- a/src/components/auctions/AuctionInfoCard/index.tsx
+++ b/src/components/auctions/AuctionInfoCard/index.tsx
@@ -268,7 +268,7 @@ const AuctionInfoCard: React.FC<Props> = (props) => {
         <Cell>
           <Subtitle>Current price</Subtitle>
           <Text>
-            {abbreviation(auctionInfo.order.price.toFixed(2))}{' '}
+            {abbreviation(auctionInfo.currentClearingPrice.toFixed(2))}{' '}
             {` ` + auctionInfo.symbolBiddingToken} per {auctionInfo.symbolAuctioningToken}
           </Text>
         </Cell>


### PR DESCRIPTION
closes #395

Tiny fix. Shows actual price instead of min price on the featured auction card.