### PR TITLE
fixing chart for boson auction

### DIFF
--- a/src/components/auction/Charts/XYChart.ts
+++ b/src/components/auction/Charts/XYChart.ts
@@ -52,7 +52,7 @@ export const XYChart = (props: XYChartProps): am4charts.XYChart => {
   const numberFormatter = new am4core.NumberFormatter()
   numberFormatter.numberFormat = '#.00a'
   numberFormatter.bigNumberPrefixes = [
-    { number: 1e4, suffix: 'K' }, // Use K only with value greater than 9999.00
+    { number: 1e3, suffix: 'K' }, // Use K only with value greater than 999.00
     { number: 1e6, suffix: 'M' }, // Million
     { number: 1e9, suffix: 'B' }, // Billion
     { number: 1e12, suffix: 'T' }, // Trillion


### PR DESCRIPTION
When our customerr was running the auction, they would get:
https://ido-ux.dev.gnosisdev.com/#/auction?auctionId=14&chainId=4#topAnchor
![image](https://user-images.githubusercontent.com/7348154/113478688-b0f25000-948a-11eb-9195-2f8fcdd39d53.png)
and it looked like only 2k volume was placed. But indeed 20k was placed

Now its fixed