### PR TITLE
(Fix) Responsive issues

### DIFF
--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -135,7 +135,7 @@ const TimerWrapper = styled.div`
 const TokenSymbol = styled.span`
   align-items: center;
   display: flex;
-  font-size: 16px;
+  font-size: 15px;
   justify-content: center;
 
   & > * {
@@ -208,7 +208,7 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
       <>
         <TokenValue>{abbreviation(clearingPriceNumber)}</TokenValue>{' '}
         <TokenSymbol>
-          {getTokenDisplay(derivedAuctionInfo?.auctioningToken)}/
+          {getTokenDisplay(derivedAuctionInfo?.auctioningToken)} per{' '}
           {getTokenDisplay(derivedAuctionInfo?.biddingToken)}
         </TokenSymbol>
       </>
@@ -329,7 +329,7 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
             </TokenValue>
             <TokenSymbol>
               {initialPriceToDisplay && auctioningTokenDisplay
-                ? ` ${auctioningTokenDisplay}/${biddingTokenDisplay}`
+                ? ` ${auctioningTokenDisplay} per ${biddingTokenDisplay}`
                 : '-'}
             </TokenSymbol>
           </>

--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -65,6 +65,7 @@ const Cell = styled(KeyValue)`
   .itemValue {
     flex-direction: column;
     flex-grow: 0;
+    margin-bottom: 0;
   }
 
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
@@ -89,7 +90,8 @@ const Cell = styled(KeyValue)`
     }
 
     .itemValue {
-      flex-direction: column;
+      flex-direction: row;
+      margin-bottom: 2px;
     }
   }
 `
@@ -159,6 +161,7 @@ const TokenValue = styled.span`
 
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
     font-size: 18px;
+    margin-bottom: 0;
     margin-right: 8px;
   }
 `

--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -24,11 +24,12 @@ const Wrapper = styled(BaseCard)`
   margin: 0 0 28px;
   max-width: 100%;
   min-height: 130px;
-  grid-template-columns: 1fr 3px 1fr;
   grid-template-areas:
     'top top top'
     'col1 sep1 col2'
     'col3 sep2 col4';
+  grid-template-columns: 1fr 3px 1fr;
+  grid-template-rows: 1fr;
   padding-bottom: 20px;
   row-gap: 15px;
 
@@ -41,8 +42,12 @@ const Wrapper = styled(BaseCard)`
 `
 
 const Cell = styled(KeyValue)`
+  height: 100%;
+  justify-content: center;
+  padding: 5px 0;
+
   &.col1 {
-    grid-area: col1;
+    grid-area: col3;
   }
 
   &.col2 {
@@ -50,14 +55,22 @@ const Cell = styled(KeyValue)`
   }
 
   &.col3 {
-    grid-area: col3;
+    grid-area: col1;
   }
 
   &.col4 {
     grid-area: col4;
   }
 
+  .itemValue {
+    flex-direction: column;
+    flex-grow: 0;
+  }
+
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    flex-grow: 1;
+    justify-content: center;
+    height: auto;
     padding: 0 10px;
 
     &.col1,
@@ -74,12 +87,17 @@ const Cell = styled(KeyValue)`
     &:last-child {
       padding-right: 0;
     }
+
+    .itemValue {
+      flex-direction: column;
+    }
   }
 `
 
 const Break = styled.div`
   background-color: ${({ theme }) => theme.primary1};
   border-radius: 3px;
+  height: 100%;
   min-height: 50px;
   width: 3px;
 
@@ -91,6 +109,8 @@ const Break = styled.div`
   }
 
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    height: auto;
+
     &.sep1,
     &.sep2 {
       grid-area: unset;
@@ -107,6 +127,39 @@ const TimerWrapper = styled.div`
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
     grid-area: unset;
     margin: 0;
+  }
+`
+
+const TokenSymbol = styled.span`
+  align-items: center;
+  display: flex;
+  font-size: 16px;
+  justify-content: center;
+
+  & > * {
+    margin-right: 8px;
+  }
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    font-size: 18px;
+  }
+`
+
+const TokenValue = styled.span`
+  align-items: center;
+  display: flex;
+  font-size: 25px;
+  justify-content: center;
+  margin-bottom: 5px;
+  margin-right: 0;
+
+  & > * {
+    margin-right: 8px;
+  }
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    font-size: 18px;
+    margin-right: 8px;
   }
 `
 
@@ -148,11 +201,17 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
       )
     const clearingPriceNumber = orderToPrice(clearingPriceInfoAsSellOrder)?.toSignificant(4)
 
-    return clearingPriceNumber
-      ? `${abbreviation(clearingPriceNumber)} ${getTokenDisplay(
-          derivedAuctionInfo?.auctioningToken,
-        )}/${getTokenDisplay(derivedAuctionInfo?.biddingToken)}`
-      : '-'
+    return clearingPriceNumber ? (
+      <>
+        <TokenValue>{abbreviation(clearingPriceNumber)}</TokenValue>{' '}
+        <TokenSymbol>
+          {getTokenDisplay(derivedAuctionInfo?.auctioningToken)}/
+          {getTokenDisplay(derivedAuctionInfo?.biddingToken)}
+        </TokenSymbol>
+      </>
+    ) : (
+      '-'
+    )
   }, [derivedAuctionInfo?.auctioningToken, derivedAuctionInfo?.biddingToken, clearingPriceInfo])
 
   const titlePrice = useMemo(
@@ -200,7 +259,7 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
         }
         itemValue={
           derivedAuctionInfo?.biddingToken ? (
-            <>
+            <TokenSymbol>
               <TokenLogo
                 size={'20px'}
                 token={{
@@ -210,7 +269,7 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
               />
               <span>{biddingTokenDisplay}</span>
               <ExternalLink href={biddingTokenAddress} />
-            </>
+            </TokenSymbol>
           ) : (
             '-'
           )
@@ -233,17 +292,13 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
         itemValue={
           derivedAuctionInfo?.auctioningToken && derivedAuctionInfo?.initialAuctionOrder ? (
             <>
-              <TokenLogo
-                size={'20px'}
-                token={{
-                  address: derivedAuctionInfo?.auctioningToken.address,
-                  symbol: derivedAuctionInfo?.auctioningToken.symbol,
-                }}
-              />
-              <span>{`${abbreviation(
-                derivedAuctionInfo?.initialAuctionOrder?.sellAmount.toSignificant(2),
-              )} ${auctioningTokenDisplay}`}</span>
-              <ExternalLink href={auctionTokenAddress} />
+              <TokenValue>
+                {abbreviation(derivedAuctionInfo?.initialAuctionOrder?.sellAmount.toSignificant(2))}
+              </TokenValue>
+              <TokenSymbol>
+                <span>{auctioningTokenDisplay}</span>
+                <ExternalLink href={auctionTokenAddress} />
+              </TokenSymbol>
             </>
           ) : (
             '-'
@@ -264,10 +319,16 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
         }
         itemValue={
           <>
-            {initialPriceToDisplay ? abbreviation(initialPriceToDisplay?.toSignificant(2)) : ' - '}
-            {initialPriceToDisplay && auctioningTokenDisplay
-              ? ` ${auctioningTokenDisplay}/${biddingTokenDisplay}`
-              : '-'}
+            <TokenValue>
+              {initialPriceToDisplay
+                ? abbreviation(initialPriceToDisplay?.toSignificant(2))
+                : ' - '}
+            </TokenValue>
+            <TokenSymbol>
+              {initialPriceToDisplay && auctioningTokenDisplay
+                ? ` ${auctioningTokenDisplay}/${biddingTokenDisplay}`
+                : '-'}
+            </TokenSymbol>
           </>
         }
       />

--- a/src/components/auctions/AllAuctions/index.tsx
+++ b/src/components/auctions/AllAuctions/index.tsx
@@ -34,9 +34,9 @@ const RowLink = styled(NavLink)<CellRowProps>`
   ${CellRowCSS}
   column-gap: 6px;
   cursor: pointer;
-  grid-template-columns: 1fr 1fr 1fr;
-  padding-left: 8px;
-  padding-right: 25px;
+  grid-template-columns: 1fr 1fr;
+  padding-left: 10px;
+  padding-right: 20px;
   row-gap: 15px;
 
   &:first-child {
@@ -63,7 +63,7 @@ const RowLink = styled(NavLink)<CellRowProps>`
 const TableCell = styled(Cell)`
   &:last-child {
     position: absolute;
-    right: 10px;
+    right: 15px;
     top: 50%;
     transform: translateY(-50%);
   }
@@ -157,9 +157,21 @@ const Pagination = styled.div`
   align-items: center;
   border-top: 1px solid ${({ theme }) => theme.border};
   display: flex;
-  height: 56px;
-  justify-content: flex-end;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 56px;
   padding: 0 15px;
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+`
+
+const PaginationBlock = styled.span`
+  align-items: center;
+  display: flex;
+  justify-content: center;
 `
 
 const PaginationTextCSS = css`
@@ -176,7 +188,12 @@ const PaginationText = styled.span`
 
 const PaginationBreak = styled.span`
   ${PaginationTextCSS}
+  display: none;
   margin: 0 12px;
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    display: block;
+  }
 `
 
 const PaginationButton = styled.button`
@@ -186,7 +203,7 @@ const PaginationButton = styled.button`
   cursor: pointer;
   display: flex;
   justify-content: center;
-  height: 35px;
+  height: auto;
   outline: none;
   padding: 0;
   user-select: none;
@@ -207,6 +224,10 @@ const PaginationButton = styled.button`
     .fill {
       color: ${({ theme }) => theme.text1};
     }
+  }
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    height: 35px;
   }
 `
 
@@ -542,38 +563,42 @@ const AllAuctions = (props: Props) => {
               )
             })}
             <Pagination>
-              <PaginationText>Items per page</PaginationText>{' '}
-              <DropdownPagination
-                dropdownButtonContent={
-                  <PaginationDropdownButton>{pageSize} ▼</PaginationDropdownButton>
-                }
-                dropdownDirection={DropdownDirection.upwards}
-                dropdownPosition={DropdownPosition.right}
-                items={[5, 10, 20, 30].map((pageSize) => (
-                  <PaginationItem
-                    key={pageSize}
-                    onClick={() => {
-                      setPageSize(Number(pageSize))
-                    }}
-                  >
-                    {pageSize}
-                  </PaginationItem>
-                ))}
-              />
+              <PaginationBlock>
+                <PaginationText>Items per page</PaginationText>{' '}
+                <DropdownPagination
+                  dropdownButtonContent={
+                    <PaginationDropdownButton>{pageSize} ▼</PaginationDropdownButton>
+                  }
+                  dropdownDirection={DropdownDirection.upwards}
+                  dropdownPosition={DropdownPosition.right}
+                  items={[5, 10, 20, 30].map((pageSize) => (
+                    <PaginationItem
+                      key={pageSize}
+                      onClick={() => {
+                        setPageSize(Number(pageSize))
+                      }}
+                    >
+                      {pageSize}
+                    </PaginationItem>
+                  ))}
+                />
+              </PaginationBlock>
               <PaginationBreak>|</PaginationBreak>
-              <PaginationText>
-                {pageIndex + 1 === 1 ? 1 : pageIndex * pageSize + 1} -{' '}
-                {rows.length < (pageIndex + 1) * pageSize
-                  ? rows.length
-                  : (pageIndex + 1) * pageSize}{' '}
-                of {rows.length} auctions
-              </PaginationText>{' '}
-              <PaginationButton disabled={!canPreviousPage} onClick={() => previousPage()}>
-                <ChevronLeft />
-              </PaginationButton>
-              <PaginationButton disabled={!canNextPage} onClick={() => nextPage()}>
-                <ChevronRight />
-              </PaginationButton>
+              <PaginationBlock>
+                <PaginationText>
+                  {pageIndex + 1 === 1 ? 1 : pageIndex * pageSize + 1} -{' '}
+                  {rows.length < (pageIndex + 1) * pageSize
+                    ? rows.length
+                    : (pageIndex + 1) * pageSize}{' '}
+                  of {rows.length} auctions
+                </PaginationText>{' '}
+                <PaginationButton disabled={!canPreviousPage} onClick={() => previousPage()}>
+                  <ChevronLeft />
+                </PaginationButton>
+                <PaginationButton disabled={!canNextPage} onClick={() => nextPage()}>
+                  <ChevronRight />
+                </PaginationButton>
+              </PaginationBlock>
             </Pagination>
           </Table>
         </>

--- a/src/components/auctions/AllAuctions/index.tsx
+++ b/src/components/auctions/AllAuctions/index.tsx
@@ -32,10 +32,11 @@ const SectionTitle = styled(PageTitle)`
 
 const RowLink = styled(NavLink)<CellRowProps>`
   ${CellRowCSS}
+  column-gap: 6px;
   cursor: pointer;
   grid-template-columns: 1fr 1fr 1fr;
-  padding-left: 10px;
-  padding-right: 10px;
+  padding-left: 8px;
+  padding-right: 25px;
   row-gap: 15px;
 
   &:first-child {
@@ -52,16 +53,17 @@ const RowLink = styled(NavLink)<CellRowProps>`
   }
 
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    column-gap: 10px;
     grid-template-columns: ${(props) => getColumns(props.columns)};
     padding-left: 15px;
-    padding-right: 30px;
+    padding-right: 15px;
   }
 `
 
 const TableCell = styled(Cell)`
   &:last-child {
     position: absolute;
-    right: 0;
+    right: 10px;
     top: 50%;
     transform: translateY(-50%);
   }

--- a/src/components/auctions/AuctionInfoCard/index.tsx
+++ b/src/components/auctions/AuctionInfoCard/index.tsx
@@ -25,12 +25,16 @@ const Wrapper = styled(HashLink)`
   flex-flow: column;
   justify-content: space-between;
   min-height: 290px;
-  padding: 12px 18px;
+  padding: 12px;
   text-decoration: none;
   transition: all 0.15s linear;
 
   &:hover {
     box-shadow: 10px -10px 24px 0 rgba(0, 34, 73, 0.7);
+  }
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    padding: 12px 18px;
   }
 `
 
@@ -43,11 +47,16 @@ const Top = styled.span`
 
 const Tokens = styled.span`
   color: ${({ theme }) => theme.text1};
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
   line-height: 1.2;
   margin: 0;
   text-transform: uppercase;
+  white-space: nowrap;
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    font-size: 24px;
+  }
 `
 
 const Badge = styled.span`
@@ -57,7 +66,12 @@ const Badge = styled.span`
   color: ${({ theme }) => theme.primary1};
   display: flex;
   height: 34px;
-  padding: 0 18px;
+  padding: 0 12px;
+  white-space: nowrap;
+
+  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
+    padding: 0 18px;
+  }
 `
 
 const Blinker = keyframes`

--- a/src/components/auctions/AuctionInfoCard/index.tsx
+++ b/src/components/auctions/AuctionInfoCard/index.tsx
@@ -34,7 +34,7 @@ const Wrapper = styled(HashLink)`
   }
 
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
-    padding: 12px 18px;
+    padding: 12px 15px;
   }
 `
 
@@ -53,10 +53,6 @@ const Tokens = styled.span`
   margin: 0;
   text-transform: uppercase;
   white-space: nowrap;
-
-  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
-    font-size: 24px;
-  }
 `
 
 const Badge = styled.span`
@@ -65,13 +61,10 @@ const Badge = styled.span`
   border-radius: 17px;
   color: ${({ theme }) => theme.primary1};
   display: flex;
-  height: 34px;
+  height: 31px;
+  line-height: 1;
   padding: 0 12px;
   white-space: nowrap;
-
-  @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
-    padding: 0 18px;
-  }
 `
 
 const Blinker = keyframes`
@@ -133,6 +126,7 @@ const PriceAndDuration = styled.span`
 const Cell = styled.span`
   display: flex;
   flex-direction: column;
+  max-width: 49%;
 `
 
 const Subtitle = styled.span<{ textAlign?: string }>`
@@ -145,6 +139,7 @@ const Subtitle = styled.span<{ textAlign?: string }>`
   opacity: 0.7;
   padding: 0 0 5px;
   text-align: ${(props) => props.textAlign};
+  white-space: nowrap;
 `
 
 Subtitle.defaultProps = {
@@ -157,6 +152,7 @@ const Text = styled.span`
   font-weight: 700;
   line-height: 1.2;
   margin-top: auto;
+  white-space: nowrap;
 `
 
 const ProgressBar = styled.span`
@@ -166,7 +162,8 @@ const ProgressBar = styled.span`
   height: 5px;
   margin-bottom: 3px;
   margin-top: auto;
-  width: 120px;
+  max-width: 100%;
+  width: 110px;
 `
 
 const Progress = styled.span<{ width: string }>`

--- a/src/components/auctions/FeaturedAuctions/index.tsx
+++ b/src/components/auctions/FeaturedAuctions/index.tsx
@@ -23,7 +23,7 @@ const Row = styled.div`
   row-gap: 20px;
 
   @media (min-width: ${({ theme }) => theme.themeBreakPoints.md}) {
-    column-gap: 40px;
+    column-gap: 30px;
     grid-template-columns: 1fr 1fr 1fr;
   }
 `

--- a/src/components/navigation/Mainmenu/index.tsx
+++ b/src/components/navigation/Mainmenu/index.tsx
@@ -39,17 +39,12 @@ const Item = styled(NavLink)`
   }
 `
 
-const IconWrapper = styled.span`
-  margin-right: 8px;
-`
-
 export const Mainmenu: React.FC = (props) => {
   return (
     <Wrapper {...props}>
       {navItems.map((item, index) => {
         return (
           <Item activeClassName="active" key={index} to={item.url}>
-            {item.icon && <IconWrapper>{item.icon}</IconWrapper>}
             {item.title}
           </Item>
         )

--- a/src/components/navigation/Mobilemenu/index.tsx
+++ b/src/components/navigation/Mobilemenu/index.tsx
@@ -32,9 +32,9 @@ const Item = styled(NavLink)`
   border-bottom: 1px solid ${({ theme }) => theme.border};
   color: ${({ theme }) => theme.text1};
   display: flex;
-  font-size: 13px;
+  font-size: 17px;
   font-weight: 400;
-  height: 42px;
+  height: 44px;
   justify-content: space-between;
   line-height: 1.2;
   padding: 0 14px;

--- a/src/components/navigation/sections.tsx
+++ b/src/components/navigation/sections.tsx
@@ -1,12 +1,7 @@
-import React from 'react'
-
-import { SendIcon } from '../icons/SendIcon'
-
 export const navItems = [
   {
     title: 'Auctions',
     url: '/overview#topAnchor',
-    icon: <SendIcon />,
   },
   {
     title: 'Docs',


### PR DESCRIPTION
Closes #415 
Closes #419

There's still room for improvement, but this should look better than before.

- #419 should be fixed.
- _Auction details may look ugly (...)_ -> Info should look better now.
- _Auction details exceed grid width (...)_ -> Should be fixed.
-  _Impossible to tap on a tooltip (...)_ -> There's not much we can do about this, we probably need to think some other solution for mobile.
- _Chart is too small on iPhone 12 mini (...)_ -> Not really a lot we can do here (especially without an iPhone 12 mini available). It looks fine in the several devices I used, though.
- _It would be nice to add a 'Back' button (...)_ -> No, that would be a nightmare. They can use the browser's back button, or the navigation menu.
- _Timing on a featured widget looks ugly when screen width < 303 px_ -> This should be fixed for most screen resolutions. We don't aim for anything below 320px wide, though (that's iPhone 4 / 5 wide). Anything less would be pretty unusual.
- _Square Icon on the Home page has dotty border (...)_ -> There's nothing to fix, that's how it looks.