### PR TITLE
(draft) Re enable Wallet Connect.

### DIFF
--- a/src/components/modals/common/WalletConnectData/index.tsx
+++ b/src/components/modals/common/WalletConnectData/index.tsx
@@ -11,6 +11,10 @@ const Wrapper = styled.div`
   margin-bottom: 20px;
 `
 
+const QR = styled(QRCode)`
+  border: 10px solid #fff;
+`
+
 interface WalletConnectDataProps {
   size: number
   uri?: string
@@ -22,7 +26,7 @@ const WalletConnectData: React.FC<WalletConnectDataProps> = (props) => {
   return (
     uri && (
       <Wrapper {...restProps}>
-        <QRCode size={size} value={uri} />
+        <QR size={size} value={uri} />
       </Wrapper>
     )
   )

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,9 +6,8 @@ import FortmaticIcon from '../assets/images/fortmaticIcon.png'
 import MetamaskIcon from '../assets/images/metamask.svg'
 import PortisIcon from '../assets/images/portisIcon.png'
 import TrustWalletIcon from '../assets/images/trustWallet.png'
-// import WalletConnectIcon from '../assets/images/wallet-connect.svg'
-// import { fortmatic, injected, portis, walletconnect, walletlink } from '../connectors'
-import { fortmatic, injected, portis, walletlink } from '../connectors'
+import WalletConnectIcon from '../assets/images/wallet-connect.svg'
+import { fortmatic, injected, portis, walletconnect, walletlink } from '../connectors'
 import { ChainId } from '../utils'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CHAIN_ID } from './config'
@@ -42,14 +41,14 @@ const MAINNET_WALLETS = {
     href: null,
     color: '#E8831D',
   },
-  // WALLET_CONNECT: {
-  //   connector: walletconnect,
-  //   name: 'WalletConnect',
-  //   icon: WalletConnectIcon,
-  //   description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
-  //   href: null,
-  //   color: '#4196FC',
-  // },
+  WALLET_CONNECT: {
+    connector: walletconnect,
+    name: 'WalletConnect',
+    icon: WalletConnectIcon,
+    description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
+    href: null,
+    color: '#4196FC',
+  },
 }
 
 // TODO This wallets are unsupported temporarily.


### PR DESCRIPTION
Regarding the latest discussions about re enabling WalletConnect:

- I created this pull request for everyone to test this.
- I added a white border to the QR code, that makes scanning it easier.
- I opened Gnosis Auction from my desktop browser, and used the WalletConnect compatible Metamask app (but any other compatible app should be the same). I could connect and had no issues.
- Metamask must be disabled on the desktop browser, otherwise it overrides WalletConnect's connection by using Metamask by default. This is pretty annoying, and possibly the main issue to fix. 
- If Metamask is absent / disabled / locked, there are no issues when connecting, or otherwise.
- Placed a few different orders (USDC, DAI, etc.), and had no issues there. All the confirmations were requested on my phone, and when confirmed the computer's browser reflected that.
- All my tests where performed on Rinkeby.
- It obviously makes not sense to have the WalletConnect option on mobile, but it's there. Maybe we can hide it.

So guys please have a look and see if this works for you, and if there's anything else you can do about these issues.