### PR TITLE
Bug: Walletconnect disconnects after page reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": ".",
   "private": true,
   "engines": {
-    "node": ">=4.4.7 <=14.15.4"
+    "node": ">=4.4.7 <=14.16.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/common/UserDropdown/index.tsx
+++ b/src/components/common/UserDropdown/index.tsx
@@ -191,6 +191,7 @@ export const UserDropdown: React.FC<Props> = (props) => {
 
   const disconnect = React.useCallback(async () => {
     deactivate()
+    localStorage.removeItem('walletconnect')
   }, [deactivate])
 
   const UserDropdownContent = () => {

--- a/src/components/modals/common/WalletConnectData/index.tsx
+++ b/src/components/modals/common/WalletConnectData/index.tsx
@@ -3,6 +3,10 @@ import styled from 'styled-components'
 
 import QRCode from 'qrcode.react'
 
+const QR = styled(QRCode)`
+  border: 10px solid #fff;
+`
+
 const Wrapper = styled.div`
   ${({ theme }) => theme.flexColumnNoWrap};
   align-items: center;
@@ -22,7 +26,7 @@ const WalletConnectData: React.FC<WalletConnectDataProps> = (props) => {
   return (
     uri && (
       <Wrapper {...restProps}>
-        <QRCode size={size} value={uri} />
+        <QR size={size} value={uri} />
       </Wrapper>
     )
   )

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,9 +6,8 @@ import FortmaticIcon from '../assets/images/fortmaticIcon.png'
 import MetamaskIcon from '../assets/images/metamask.svg'
 import PortisIcon from '../assets/images/portisIcon.png'
 import TrustWalletIcon from '../assets/images/trustWallet.png'
-// import WalletConnectIcon from '../assets/images/wallet-connect.svg'
-// import { fortmatic, injected, portis, walletconnect, walletlink } from '../connectors'
-import { fortmatic, injected, portis, walletlink } from '../connectors'
+import WalletConnectIcon from '../assets/images/wallet-connect.svg'
+import { fortmatic, injected, portis, walletconnect, walletlink } from '../connectors'
 import { ChainId } from '../utils'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { CHAIN_ID } from './config'
@@ -42,14 +41,14 @@ const MAINNET_WALLETS = {
     href: null,
     color: '#E8831D',
   },
-  // WALLET_CONNECT: {
-  //   connector: walletconnect,
-  //   name: 'WalletConnect',
-  //   icon: WalletConnectIcon,
-  //   description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
-  //   href: null,
-  //   color: '#4196FC',
-  // },
+  WALLET_CONNECT: {
+    connector: walletconnect,
+    name: 'WalletConnect',
+    icon: WalletConnectIcon,
+    description: 'Connect to Trust Wallet, Rainbow Wallet and more...',
+    href: null,
+    color: '#4196FC',
+  },
 }
 
 // TODO This wallets are unsupported temporarily.


### PR DESCRIPTION
So the problem was that the `useEagerConnect` hook only checks if there's an existing metamask connection, it doesn't check walletconnect. 

This PR:
- Add walletconnect check to useEagerConnect
- Increase supported node versions in package.json