### PR TITLE
(fix) token logo on mobile

### DIFF
--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -262,17 +262,20 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
         }
         itemValue={
           derivedAuctionInfo?.biddingToken ? (
-            <TokenSymbol>
-              <TokenLogo
-                size={'20px'}
-                token={{
-                  address: derivedAuctionInfo?.biddingToken.address,
-                  symbol: derivedAuctionInfo?.biddingToken.symbol,
-                }}
-              />
-              <span>{biddingTokenDisplay}</span>
-              <ExternalLink href={biddingTokenAddress} />
-            </TokenSymbol>
+            <>
+              <TokenValue>&nbsp;</TokenValue>
+              <TokenSymbol>
+                <span>{biddingTokenDisplay}</span>
+                <TokenLogo
+                  size={'20px'}
+                  token={{
+                    address: derivedAuctionInfo?.biddingToken.address,
+                    symbol: derivedAuctionInfo?.biddingToken.symbol,
+                  }}
+                />
+                <ExternalLink href={biddingTokenAddress} />
+              </TokenSymbol>
+            </>
           ) : (
             '-'
           )
@@ -295,18 +298,18 @@ const AuctionDetails = (props: AuctionDetailsProps) => {
         itemValue={
           derivedAuctionInfo?.auctioningToken && derivedAuctionInfo?.initialAuctionOrder ? (
             <>
-              <TokenLogo
-                size={'20px'}
-                token={{
-                  address: derivedAuctionInfo?.auctioningToken.address,
-                  symbol: derivedAuctionInfo?.auctioningToken.symbol,
-                }}
-              />
               <TokenValue>
                 {abbreviation(derivedAuctionInfo?.initialAuctionOrder?.sellAmount.toSignificant(4))}
               </TokenValue>
               <TokenSymbol>
                 <span>{auctioningTokenDisplay}</span>
+                <TokenLogo
+                  size={'20px'}
+                  token={{
+                    address: derivedAuctionInfo?.auctioningToken.address,
+                    symbol: derivedAuctionInfo?.auctioningToken.symbol,
+                  }}
+                />
                 <ExternalLink href={auctionTokenAddress} />
               </TokenSymbol>
             </>


### PR DESCRIPTION
Closes #461 

I moved the tokens' logos to the right so it's easier to put the numbers on top when on mobile.