### PR TITLE
Does not allow to place orders below the clearing price

### DIFF
--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -148,7 +148,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
   const orders: OrderState | undefined = useOrderState()
   const toggleWalletModal = useWalletModalToggle()
   const { chainId: auctionChainId, price, sellAmount } = useSwapState()
-  const { error } = useGetOrderPlacementError(derivedAuctionInfo)
+  const { error } = useGetOrderPlacementError(derivedAuctionInfo, auctionState)
   const { onUserSellAmountInput } = useSwapActionHandlers()
   const { onUserPriceInput } = useSwapActionHandlers()
   const auctionInfo = useAuctionDetails(auctionIdentifier)

--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -175,6 +175,7 @@ export function tryParseAmount(value?: string, token?: Token): TokenAmount | und
 
 export function useGetOrderPlacementError(
   derivedAuctionInfo: DerivedAuctionInfo,
+  auctionState: AuctionState,
 ): {
   error?: string
 } {
@@ -238,6 +239,23 @@ export function useGetOrderPlacementError(
   ) {
     error =
       error ?? 'Price must be higher than ' + derivedAuctionInfo?.initialPrice?.toSignificant(5)
+  }
+
+  if (
+    derivedAuctionInfo?.clearingPriceSellOrder != null &&
+    derivedAuctionInfo?.clearingPrice != null &&
+    derivedAuctionInfo?.auctioningToken != undefined &&
+    derivedAuctionInfo?.biddingToken != undefined &&
+    auctionState == AuctionState.ORDER_PLACING &&
+    buyAmountScaled &&
+    sellAmountScaled
+      ?.mul(derivedAuctionInfo?.clearingPriceSellOrder?.buyAmount.raw.toString())
+      .lte(
+        buyAmountScaled.mul(derivedAuctionInfo?.clearingPriceSellOrder?.sellAmount.raw.toString()),
+      )
+  ) {
+    error =
+      error ?? 'Price must be higher than ' + derivedAuctionInfo?.clearingPrice?.toSignificant(5)
   }
 
   const [balanceIn, amountIn] = [biddingTokenBalance, parsedBiddingAmount]

--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -228,18 +228,6 @@ export function useGetOrderPlacementError(
   ) {
     error = 'Please wait a sec'
   }
-  if (
-    derivedAuctionInfo?.initialAuctionOrder != null &&
-    derivedAuctionInfo?.auctioningToken != undefined &&
-    derivedAuctionInfo?.biddingToken != undefined &&
-    buyAmountScaled &&
-    sellAmountScaled
-      ?.mul(derivedAuctionInfo?.initialAuctionOrder?.sellAmount.raw.toString())
-      .lte(buyAmountScaled.mul(derivedAuctionInfo?.initialAuctionOrder?.buyAmount.raw.toString()))
-  ) {
-    error =
-      error ?? 'Price must be higher than ' + derivedAuctionInfo?.initialPrice?.toSignificant(5)
-  }
 
   if (
     derivedAuctionInfo?.clearingPriceSellOrder != null &&
@@ -256,6 +244,19 @@ export function useGetOrderPlacementError(
   ) {
     error =
       error ?? 'Price must be higher than ' + derivedAuctionInfo?.clearingPrice?.toSignificant(5)
+  }
+
+  if (
+    derivedAuctionInfo?.initialAuctionOrder != null &&
+    derivedAuctionInfo?.auctioningToken != undefined &&
+    derivedAuctionInfo?.biddingToken != undefined &&
+    buyAmountScaled &&
+    sellAmountScaled
+      ?.mul(derivedAuctionInfo?.initialAuctionOrder?.sellAmount.raw.toString())
+      .lte(buyAmountScaled.mul(derivedAuctionInfo?.initialAuctionOrder?.buyAmount.raw.toString()))
+  ) {
+    error =
+      error ?? 'Price must be higher than ' + derivedAuctionInfo?.initialPrice?.toSignificant(5)
   }
 
   const [balanceIn, amountIn] = [biddingTokenBalance, parsedBiddingAmount]


### PR DESCRIPTION
Users were placing orders bleow the clearing price, although this makes no sense and they are just wasting gas.

Hence, in the no-order-cancelation phase, we don't allow placing orders below the current clearing price, as the clearing price can only increase.

can be easily tested on auction: `auction?auctionId=33&chainId=4#topAnchor`