### PR TITLE
(Fix) Waiting modal appears when clicking on the Claim button again

### DIFF
--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -60,54 +60,56 @@ const Text = styled.div`
   line-height: 1.2;
   margin-left: 10px;
 `
-interface ClaimerProps {
+
+interface Props {
   auctionIdentifier: AuctionIdentifier
   derivedAuctionInfo: DerivedAuctionInfo
 }
-const Claimer: React.FC<ClaimerProps> = (props) => {
+
+const Claimer: React.FC<Props> = (props) => {
   const { auctionIdentifier, derivedAuctionInfo } = props
   const { account } = useActiveWeb3React()
-  const toggleWalletModal = useWalletModalToggle()
-  const { error } = useDerivedClaimInfo(auctionIdentifier)
-
-  const isValid = !error
   const [showConfirm, setShowConfirm] = useState<boolean>(false)
-  const [pendingConfirmation, setPendingConfirmation] = useState<boolean>(true) // waiting for user confirmation
+  const [userConfirmedTx, setUserConfirmedTx] = useState<boolean>(false)
+  const [pendingConfirmation, setPendingConfirmation] = useState<boolean>(true)
+  const [txHash, setTxHash] = useState<string>('')
+  const pendingText = `Claiming Funds`
+  const { error, isLoadingClaimInfo } = useDerivedClaimInfo(auctionIdentifier)
+  const isValid = !error
+  const toggleWalletModal = useWalletModalToggle()
 
   const { claimableAuctioningToken, claimableBiddingToken } = useGetAuctionProceeds(
     auctionIdentifier,
     derivedAuctionInfo,
   )
-  const [txHash, setTxHash] = useState<string>('')
 
-  function resetModal() {
-    setPendingConfirmation(true)
-  }
-
+  const resetModal = () => setPendingConfirmation(true)
   const claimOrderCallback = useClaimOrderCallback(auctionIdentifier)
 
-  function onClaimOrder() {
+  const onClaimOrder = () =>
     claimOrderCallback()
       .then((hash) => {
         setTxHash(hash)
         setPendingConfirmation(false)
+        setUserConfirmedTx(true)
       })
       .catch(() => {
         resetModal()
         setShowConfirm(false)
+        setUserConfirmedTx(false)
       })
-  }
 
-  const pendingText = `Claiming Funds`
   const biddingTokenDisplay = useMemo(() => getTokenDisplay(derivedAuctionInfo?.biddingToken), [
     derivedAuctionInfo,
   ])
+
   const auctioningTokenDisplay = useMemo(
     () => getTokenDisplay(derivedAuctionInfo?.auctioningToken),
     [derivedAuctionInfo],
   )
 
-  const isLoading = !claimableBiddingToken || !claimableAuctioningToken
+  const isLoading = isLoadingClaimInfo || !claimableBiddingToken || !claimableAuctioningToken
+  const isClaimButtonDisabled = !isValid || showConfirm || isLoading || userConfirmedTx
 
   return (
     <Wrapper>
@@ -170,7 +172,7 @@ const Claimer: React.FC<ClaimerProps> = (props) => {
             <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>
           ) : (
             <ActionButton
-              disabled={!isValid}
+              disabled={isClaimButtonDisabled}
               onClick={() => {
                 setShowConfirm(true)
                 onClaimOrder()

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -267,6 +267,8 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
     [auctionInfo],
   )
   const signatureAvailable = React.useMemo(() => signature && signature.length > 10, [signature])
+  const isPlaceOrderDisabled =
+    !isValid || notApproved || showWarning || showWarningWrongChainId || showConfirm
 
   return (
     <>
@@ -366,7 +368,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
             {!account ? (
               <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>
             ) : (
-              <ActionButton disabled={!isValid || notApproved} onClick={handleShowConfirm}>
+              <ActionButton disabled={isPlaceOrderDisabled} onClick={handleShowConfirm}>
                 Place Order
               </ActionButton>
             )}

--- a/src/hooks/useClaimOrderCallback.ts
+++ b/src/hooks/useClaimOrderCallback.ts
@@ -155,11 +155,13 @@ export function useClaimOrderCallback(
       if (!chainId || !library || !account || !claimInfo) {
         throw new Error('missing dependencies in onPlaceOrder callback')
       }
+
       const easyAuctionContract: Contract = getEasyAuctionContract(
         chainId as ChainId,
         library,
         account,
       )
+
       let estimate,
         method: Function,
         args: Array<string | string[] | number>,
@@ -182,7 +184,6 @@ export function useClaimOrderCallback(
           addTransaction(response, {
             summary: 'Claiming tokens',
           })
-
           return response.hash
         })
         .catch((error) => {

--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -492,8 +492,6 @@ export function useDerivedClaimInfo(
     auctioningToken,
   )
 
-  let error: string | undefined = ''
-
   const claimableOrders = useGetClaimInfo(auctionIdentifier)?.sellOrdersFormUser
   const claimed = useSingleCallResult(easyAuctionInstance, 'containsOrder', [
     auctionId,
@@ -506,17 +504,16 @@ export function useDerivedClaimInfo(
       : claimableOrders[0],
   ]).result
 
-  if (clearingPriceSellOrder?.buyAmount.raw.toString() === '0') {
-    error = 'Price not yet supplied to auction.'
-  } else if (auctionEndDate >= new Date().getTime() / 1000) {
-    error = 'Auction has not yet ended.'
-  } else if (claimableOrders === undefined || claimableOrders?.length > 0) {
-    if (!claimed || !claimed[0]) {
-      error = 'You already claimed your funds.'
-    }
-  } else if (claimableOrders?.length === 0) {
-    error = 'You had no participation on this auction.'
-  }
+  const error =
+    clearingPriceSellOrder?.buyAmount.raw.toString() === '0'
+      ? 'Price not yet supplied to auction.'
+      : auctionEndDate >= new Date().getTime() / 1000
+      ? 'Auction has not yet ended.'
+      : (claimableOrders === undefined || claimableOrders?.length > 0) && claimed && !claimed[0]
+      ? 'You already claimed your funds.'
+      : claimableOrders?.length === 0
+      ? 'You had no participation on this auction.'
+      : ''
 
   return {
     error,


### PR DESCRIPTION
Closes #359 

This should work better now.

In the future we should modify the "Error" logic to make it capable of dealing with different status returned by the hooks.

We should be able to discern if we are dealing with an actual error, or if we are dealing with a "Success" status (ie: "You already claimed your funds" is an OK status and it should display a green checkmark, and not the red warning icon).