### PR TITLE
fix: non-participants don't get a spinner for claiming dialog

### DIFF
--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -536,7 +536,7 @@ export function useDerivedClaimInfo(
     !auctioningToken ||
     !biddingToken ||
     !clearingPriceSellOrder ||
-    !claimableOrders ||
+    claimableOrders == undefined ||
     !claimed
 
   return {


### PR DESCRIPTION
non-participants of an auction would always get a spinner instead of the claiming dialogue. This PR fixes it.