### PR TITLE
fix for order deletion during order placmeent

### DIFF
--- a/src/components/auction/AuctionDetails/index.tsx
+++ b/src/components/auction/AuctionDetails/index.tsx
@@ -8,11 +8,13 @@ import {
   DerivedAuctionInfo,
   orderToPrice,
   orderToSellOrder,
+  useSwapActionHandlers,
   useSwapState,
 } from '../../../state/orderPlacement/hooks'
 import { AuctionIdentifier } from '../../../state/orderPlacement/reducer'
 import { getExplorerLink, getTokenDisplay } from '../../../utils'
 import { abbreviation } from '../../../utils/numeral'
+import { showChartsInverted } from '../../../utils/prices'
 import { KeyValue } from '../../common/KeyValue'
 import { Tooltip } from '../../common/Tooltip'
 import { ExternalLink } from '../../navigation/ExternalLink'
@@ -164,13 +166,24 @@ const AuctionDetails = (props: Props) => {
     () => getExplorerLink(chainId, derivedAuctionInfo?.auctioningToken?.address, 'address'),
     [chainId, derivedAuctionInfo?.auctioningToken],
   )
+  const { showPriceInverted } = useSwapState()
+  const { onInvertPrices } = useSwapActionHandlers()
+
+  // Start with inverted prices, if orderbook is also show inverted,
+  // i.e. if the baseToken/auctioningToken is a stable token
+  React.useEffect(() => {
+    if (derivedAuctionInfo?.auctioningToken != null && !showPriceInverted) {
+      if (showChartsInverted(derivedAuctionInfo?.auctioningToken)) {
+        onInvertPrices()
+      }
+    }
+  }, [derivedAuctionInfo?.auctioningToken, onInvertPrices, showPriceInverted])
 
   const biddingTokenAddress = useMemo(
     () => getExplorerLink(chainId, derivedAuctionInfo?.biddingToken?.address, 'address'),
     [chainId, derivedAuctionInfo?.biddingToken],
   )
 
-  const { showPriceInverted } = useSwapState()
   const { clearingPriceInfo } = useClearingPriceInfo(auctionIdentifier)
   const biddingTokenDisplay = useMemo(
     () => getTokenDisplay(derivedAuctionInfo?.biddingToken, chainId),

--- a/src/components/auction/OrdersTable/index.tsx
+++ b/src/components/auction/OrdersTable/index.tsx
@@ -175,6 +175,14 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
 
   useAllUserOrders(auctionIdentifier, derivedAuctionInfo)
 
+  const priceExplainer = React.useMemo(
+    () =>
+      showPriceInverted
+        ? 'The minimum price you are willing to participate at. You might receive a better price, but if the clearing price is lower, you will not participate and can claim your funds back when the auction ends.'
+        : 'The maximum price you are willing to participate at. You might receive a better price, but if the clearing price is higher, you will not participate and can claim your funds back when the auction ends.',
+    [showPriceInverted],
+  )
+
   return (
     <Wrapper {...restProps}>
       <Title as="h2">Your Orders</Title>
@@ -221,14 +229,7 @@ const OrderTable: React.FC<OrderTableProps> = (props) => {
                   itemKey={
                     <>
                       <span>Limit Price</span>
-                      <Tooltip
-                        id={`limitPrice_${index}`}
-                        text={
-                          showPriceInverted
-                            ? 'The minimum price you are willing to participate at. You might receive a better price, but if the clearing price is lower, you will not participate and can claim your funds back when the auction ends.'
-                            : 'The maximum price you are willing to participate at. You might receive a better price, but if the clearing price is higher, you will not participate and can claim your funds back when the auction ends.'
-                        }
-                      />
+                      <Tooltip id={`limitPrice_${index}`} text={priceExplainer} />
                     </>
                   }
                   itemValue={abbreviation(

--- a/src/pages/Auction/index.tsx
+++ b/src/pages/Auction/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import styled, { css } from 'styled-components'
 
@@ -9,16 +9,10 @@ import { InlineLoading } from '../../components/common/InlineLoading'
 import { NetworkIcon } from '../../components/icons/NetworkIcon'
 import WarningModal from '../../components/modals/WarningModal'
 import { PageTitle } from '../../components/pureStyledComponents/PageTitle'
-import {
-  useDefaultsFromURLSearch,
-  useDerivedAuctionInfo,
-  useSwapActionHandlers,
-  useSwapState,
-} from '../../state/orderPlacement/hooks'
+import { useDefaultsFromURLSearch, useDerivedAuctionInfo } from '../../state/orderPlacement/hooks'
 import { parseURL } from '../../state/orderPlacement/reducer'
 import { useTokenListState } from '../../state/tokenList/hooks'
 import { isAddress } from '../../utils'
-import { showChartsInverted } from '../../utils/prices'
 import { getChainName } from '../../utils/tools'
 
 const Title = styled(PageTitle)`
@@ -88,17 +82,6 @@ const Auction: React.FC<Props> = (props) => {
 
   const biddingTokenAddress = derivedAuctionInfo?.biddingToken?.address
   const auctioningTokenAddress = derivedAuctionInfo?.auctioningToken?.address
-  const { onInvertPrices } = useSwapActionHandlers()
-  const { showPriceInverted } = useSwapState()
-  // Start with inverted prices, if orderbook is also show inverted,
-  // i.e. if the baseToken/auctioningToken is a stable token
-  useEffect(() => {
-    if (derivedAuctionInfo?.auctioningToken != null && !showPriceInverted) {
-      if (showChartsInverted(derivedAuctionInfo?.auctioningToken)) {
-        onInvertPrices()
-      }
-    }
-  }, [derivedAuctionInfo?.auctioningToken, onInvertPrices, showPriceInverted])
   const validBiddingTokenAddress =
     biddingTokenAddress !== undefined &&
     isAddress(biddingTokenAddress) &&


### PR DESCRIPTION
This fixes somehow the issue:
https://github.com/henrypalacios/ido-ux/issues/2

By shifting the logic for the price invention into a lower-level component, we are saving some rerendering. This rerendering previously also always triggered  the new API call to get the user orders, as the actionidentifier was a new object, and hence it would reload the orders without the not yet mined order.