### PR TITLE
Always claim wxdai, instead of xdai

### DIFF
--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -138,7 +138,7 @@ const Claimer: React.FC<Props> = (props) => {
                         symbol: biddingTokenDisplay,
                       }}
                     />
-                    <Text>{biddingTokenDisplay}</Text>
+                    <Text>{biddingTokenDisplay != 'XDAI' ? biddingTokenDisplay : `WXDAI`}</Text>
                   </>
                 ) : (
                   '-'


### PR DESCRIPTION
Since the contracts can not pay out xdai, we should always show to claim wxdai

Eg. test on auction auction?auctionId=21&chainId=100#topAnchor