### PR TITLE
adds metamask addWalletFunctionality

### DIFF
--- a/src/components/layout/Header/index.tsx
+++ b/src/components/layout/Header/index.tsx
@@ -5,9 +5,11 @@ import styled from 'styled-components'
 import { useWeb3React } from '@web3-react/core'
 import { HashLink } from 'react-router-hash-link'
 
+import { injected } from '../../../connectors'
 import { chainNames } from '../../../constants'
 import { useWalletModalToggle } from '../../../state/application/hooks'
 import { useOrderPlacementState } from '../../../state/orderPlacement/hooks'
+import { setupNetwork } from '../../../utils/setupNetwork'
 import { getChainName } from '../../../utils/tools'
 import { ButtonConnect } from '../../buttons/ButtonConnect'
 import { ButtonMenu } from '../../buttons/ButtonMenu'
@@ -115,7 +117,7 @@ const ErrorText = styled.span`
 
 export const Component: React.FC<RouteComponentProps> = (props) => {
   const { location, ...restProps } = props
-  const { account } = useWeb3React()
+  const { account, activate } = useWeb3React()
   const { chainId } = useOrderPlacementState()
   const { errorWrongNetwork } = useNetworkCheck()
   const isConnected = !!account
@@ -142,6 +144,16 @@ export const Component: React.FC<RouteComponentProps> = (props) => {
     () => errorWrongNetwork === NetworkError.noChainMatch && isAuctionPage,
     [errorWrongNetwork, isAuctionPage],
   )
+  React.useEffect(() => {
+    const trySwitchingNetworks = async (): Promise<void> => {
+      const previouslyUsedWalletConnect = localStorage.getItem('walletconnect')
+      if (!previouslyUsedWalletConnect && chainMismatch && chainId == 100) {
+        await setupNetwork(chainId)
+        activate(injected, undefined, true)
+      }
+    }
+    trySwitchingNetworks()
+  }, [chainMismatch, activate, chainId])
 
   return (
     <>

--- a/src/components/modals/WalletModal/index.tsx
+++ b/src/components/modals/WalletModal/index.tsx
@@ -12,6 +12,7 @@ import usePrevious from '../../../hooks/usePrevious'
 import { useWalletModalOpen, useWalletModalToggle } from '../../../state/application/hooks'
 import { useOrderPlacementState } from '../../../state/orderPlacement/hooks'
 import { ExternalLink } from '../../../theme'
+import { setupNetwork } from '../../../utils/setupNetwork'
 import { AlertIcon } from '../../icons/AlertIcon'
 import { Checkbox } from '../../pureStyledComponents/Checkbox'
 import { useNetworkCheck } from '../../web3/Web3Status'
@@ -164,11 +165,15 @@ const WalletModal: React.FC = () => {
       if (connector[chainId]) {
         setPendingWallet(connector[chainId]) // set wallet for pending view
         setWalletView(WALLET_VIEWS.PENDING)
+
         await activate(connector[chainId], undefined, true)
       } else {
         setPendingWallet(connector) // set wallet for pending view
         setWalletView(WALLET_VIEWS.PENDING)
-        await activate(connector, undefined, true)
+        const hasSetup = await setupNetwork(chainId)
+        if (hasSetup) {
+          await activate(connector, undefined, true)
+        }
       }
     } catch (error) {
       if (error instanceof UnsupportedChainIdError) {

--- a/src/ethereum.d.ts
+++ b/src/ethereum.d.ts
@@ -3,6 +3,7 @@ interface Window {
     isMetaMask?: true;
     on?: (...args: any[]) => void;
     removeListener?: (...args: any[]) => void;
+    request?: (...args: any[]) => void
   };
   web3?: unknown;
 }

--- a/src/utils/setupNetwork.ts
+++ b/src/utils/setupNetwork.ts
@@ -1,0 +1,34 @@
+export const setupNetwork = async (chainId: number) => {
+  const provider = (window as Window).ethereum
+  if (provider && provider.request) {
+    try {
+      if (chainId === 100) {
+        await provider.request({
+          method: 'wallet_addEthereumChain',
+          params: [
+            {
+              chainId: `0x${chainId.toString(16)}`,
+              chainName: 'xDai',
+              nativeCurrency: {
+                name: 'xDai',
+                symbol: 'xDai',
+                decimals: 18,
+              },
+              rpcUrls: ['https://rpc.xdaichain.com/'],
+              blockExplorerUrls: ['https://blockscout.com/xdai/mainnet'],
+            },
+          ],
+        })
+      }
+      return true
+    } catch (error) {
+      console.error(error)
+      return false
+    }
+  } else {
+    console.error(
+      `Can't setup the network with chainId: ${chainId} on metamask because window.ethereum is undefined`,
+    )
+    return false
+  }
+}


### PR DESCRIPTION
closes #513


Since metamask does not yet implement the [switching functionality](https://github.com/ethereum/EIPs/pull/3326), this PR only implements the adding network functionality and with it comes automatically the switching network to xdai functionality.

Try it out:
- have metamask locked
- visit the website
- choose an xdai auction
- click connect