### PR TITLE
Add warn risk not covering Clearing Price

### DIFF
--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -170,6 +170,9 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
   const [attemptingTxn, setAttemptingTxn] = useState<boolean>(false) // clicked confirmed
   const [pendingConfirmation, setPendingConfirmation] = useState<boolean>(true) // waiting for user confirmation
   const [txHash, setTxHash] = useState<string>('')
+  const [hasRiskNotCoveringClearingPrice, setHasRiskNotCoveringClearingPrice] = useState<boolean>(
+    false,
+  )
 
   const auctioningToken = React.useMemo(() => derivedAuctionInfo.auctioningToken, [
     derivedAuctionInfo.auctioningToken,
@@ -221,6 +224,44 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
     }
   }, [onUserPriceInput, price, derivedAuctionInfo, showPriceInverted])
 
+  useEffect(() => {
+    const coversClearingPrice = (price: string | undefined, lessThan: boolean): boolean => {
+      if (!price || price === '-') {
+        return false
+      }
+      const [intPart, decimalsPart = ''] = price.split('.')
+      const decimals = decimalsPart.length
+
+      const divisor = 10n ** BigInt(decimals)
+      const priceSanitized = BigInt(Number(intPart))
+      const fractionPrice = new Fraction(priceSanitized * divisor, divisor)
+      // eslint-disable-next-line no-console
+      console.log(
+        'decimals',
+        divisor.toString(),
+        'priceSanitized',
+        priceSanitized,
+        'clearingPrice',
+        derivedAuctionInfo.clearingPrice.toSignificant(2),
+        'invert',
+        derivedAuctionInfo.clearingPrice.invert().toSignificant(6),
+        'franctionPrice',
+        fractionPrice.toSignificant(2),
+        'less:',
+        lessThan,
+      )
+
+      return lessThan
+        ? derivedAuctionInfo.clearingPrice.invert().lessThan(fractionPrice.invert())
+        : derivedAuctionInfo.clearingPrice.greaterThan(fractionPrice)
+    }
+
+    setHasRiskNotCoveringClearingPrice(
+      auctionState === AuctionState.ORDER_PLACING_AND_CANCELING &&
+        coversClearingPrice(price, showPriceInverted),
+    )
+  }, [price, derivedAuctionInfo, showPriceInverted, auctionState])
+
   const resetModal = () => {
     if (!pendingConfirmation) {
       onUserSellAmountInput('')
@@ -262,7 +303,6 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
   ])
   const notApproved = approval === ApprovalState.NOT_APPROVED || approval === ApprovalState.PENDING
   const orderPlacingOnly = auctionState === AuctionState.ORDER_PLACING
-
   const handleShowConfirm = () => {
     if (chainId !== chainIdFromWeb3) {
       setShowWarningWrongChainId(true)
@@ -437,6 +477,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
             cancelDate={cancelDate}
             chainId={chainId}
             confirmText={'Confirm'}
+            hasRiskNotCoveringClearingPrice={hasRiskNotCoveringClearingPrice}
             isPriceInverted={showPriceInverted}
             onPlaceOrder={onPlaceOrder}
             orderPlacingOnly={orderPlacingOnly}

--- a/src/components/modals/common/PlaceOrderModalFooter/index.tsx
+++ b/src/components/modals/common/PlaceOrderModalFooter/index.tsx
@@ -55,6 +55,7 @@ interface Props {
   cancelDate?: string
   confirmText: string
   onPlaceOrder: () => any
+  hasRiskNotCoveringClearingPrice: boolean
   orderPlacingOnly?: boolean
   price: string
   priceImpactWithoutFee?: Percent
@@ -65,6 +66,17 @@ interface Props {
   isPriceInverted?: boolean
 }
 
+const WarnMessageStyled: React.FC = ({ children }) => (
+  <>
+    <ErrorWrapper>
+      <ErrorRowStyled>
+        <ErrorLock />
+        <ErrorText>{children}</ErrorText>
+      </ErrorRowStyled>
+    </ErrorWrapper>
+  </>
+)
+
 const SwapModalFooter: React.FC<Props> = (props) => {
   const {
     auctioningToken,
@@ -72,6 +84,7 @@ const SwapModalFooter: React.FC<Props> = (props) => {
     cancelDate,
     chainId,
     confirmText,
+    hasRiskNotCoveringClearingPrice,
     isPriceInverted,
     onPlaceOrder,
     orderPlacingOnly,
@@ -153,26 +166,23 @@ const SwapModalFooter: React.FC<Props> = (props) => {
         </Value>
       </Row>
       {orderPlacingOnly && !cancelDate && (
-        <ErrorWrapper>
-          <ErrorRowStyled>
-            <ErrorLock />
-            <ErrorText>
-              Remember: You won&apos;t be able to cancel this order after you click the{' '}
-              <strong>&quot;Confirm&quot;</strong>
-              button.
-            </ErrorText>
-          </ErrorRowStyled>
-        </ErrorWrapper>
+        <WarnMessageStyled>
+          Remember: You won&apos;t be able to cancel this order after you click the{' '}
+          <strong>&quot;Confirm&quot;</strong>
+          button.
+        </WarnMessageStyled>
       )}
       {cancelDate && (
-        <ErrorWrapper>
-          <ErrorRowStyled>
-            <ErrorLock />
-            <ErrorText>
-              Remember: After <strong>{cancelDate}</strong> orders cannot be canceled.
-            </ErrorText>
-          </ErrorRowStyled>
-        </ErrorWrapper>
+        <WarnMessageStyled>
+          Remember: After <strong>{cancelDate}</strong> orders cannot be canceled.
+        </WarnMessageStyled>
+      )}
+      {hasRiskNotCoveringClearingPrice && (
+        <WarnMessageStyled>
+          You are placing an order <strong>{isPriceInverted ? 'above' : 'below'}</strong> the
+          current clearing price. Most likely your order will not succeed in buying{' '}
+          <strong>{auctioningToken.symbol}</strong>.
+        </WarnMessageStyled>
       )}
       <ActionButton onClick={onPlaceOrder}>{confirmText}</ActionButton>
     </>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": [
       "dom",
       "dom.iterable",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es5",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
closes: #469 

Added **verification** when the placement price is _below_ the **cleatingPrice**.

After pressing "Place Order" if the the `auctionSTate` is `ORDER_PLACING_AND_CANCELING` and the price is __below__ the `clearingPrice` This allows a **warning message** to be displayed to the user.
![Selection_275](https://user-images.githubusercontent.com/4270166/117387295-045b2200-aebf-11eb-9bdf-34ba51d3ab34.png)

⚠️ In doing so, I came across this with this [issue](https://github.com/gnosis/ido-ux/issues/548).

**Enviroment:**
auctionId: 69
chainId: 4

