### PR TITLE
(add) wrap / unwrap buttons

### DIFF
--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -151,7 +151,7 @@ const Claimer: React.FC<Props> = (props) => {
                       }}
                     />
                     <Text>{biddingTokenDisplay != 'XDAI' ? biddingTokenDisplay : `WXDAI`}</Text>
-                    {isTokenXDAI(derivedAuctionInfo?.biddingToken.address, chainId) ? (
+                    {isTokenXDAI(derivedAuctionInfo?.biddingToken.address, chainId) && (
                       <span
                         className={`tooltipComponent`}
                         data-for={'wrap_button'}
@@ -179,7 +179,7 @@ const Claimer: React.FC<Props> = (props) => {
                           Unwrap
                         </ButtonWrap>
                       </span>
-                    ) : null}
+                    )}
                   </>
                 ) : (
                   '-'

--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 
+import ReactTooltip from 'react-tooltip'
+
 import { useActiveWeb3React } from '../../../hooks'
 import { useClaimOrderCallback, useGetAuctionProceeds } from '../../../hooks/useClaimOrderCallback'
 import { useWalletModalToggle } from '../../../state/application/hooks'
@@ -8,6 +10,8 @@ import { DerivedAuctionInfo, useDerivedClaimInfo } from '../../../state/orderPla
 import { AuctionIdentifier } from '../../../state/orderPlacement/reducer'
 import { getTokenDisplay } from '../../../utils'
 import { Button } from '../../buttons/Button'
+import { ButtonAnchor } from '../../buttons/ButtonAnchor'
+import { ButtonType } from '../../buttons/buttonStylingTypes'
 import { InlineLoading } from '../../common/InlineLoading'
 import { SpinnerSize } from '../../common/Spinner'
 import { ErrorInfo } from '../../icons/ErrorInfo'
@@ -59,6 +63,14 @@ const Text = styled.div`
   font-weight: 600;
   line-height: 1.2;
   margin-left: 10px;
+`
+
+const ButtonWrap = styled(ButtonAnchor)`
+  border-radius: 4px;
+  font-size: 12px;
+  height: 20px;
+  margin: -2px 0 0 15px;
+  padding: 0 5px;
 `
 
 interface Props {
@@ -139,6 +151,33 @@ const Claimer: React.FC<Props> = (props) => {
                       }}
                     />
                     <Text>{biddingTokenDisplay != 'XDAI' ? biddingTokenDisplay : `WXDAI`}</Text>
+                    <span
+                      className={`tooltipComponent`}
+                      data-for={'wrap_button'}
+                      data-html={true}
+                      data-multiline={true}
+                      data-tip={`Unwrap ${derivedAuctionInfo?.biddingToken.symbol} on Honeyswap`}
+                    >
+                      <ReactTooltip
+                        arrowColor={'#001429'}
+                        backgroundColor={'#001429'}
+                        border
+                        borderColor={'#174172'}
+                        className="customTooltip"
+                        delayHide={50}
+                        delayShow={250}
+                        effect="solid"
+                        id={'wrap_button'}
+                        textColor="#fff"
+                      />
+                      <ButtonWrap
+                        buttonType={ButtonType.primaryInverted}
+                        href={`https://app.honeyswap.org/#/swap?outputCurrency=${derivedAuctionInfo?.biddingToken.address}`}
+                        target="_blank"
+                      >
+                        Unwrap
+                      </ButtonWrap>
+                    </span>
                   </>
                 ) : (
                   '-'

--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -8,7 +8,7 @@ import { useClaimOrderCallback, useGetAuctionProceeds } from '../../../hooks/use
 import { useWalletModalToggle } from '../../../state/application/hooks'
 import { DerivedAuctionInfo, useDerivedClaimInfo } from '../../../state/orderPlacement/hooks'
 import { AuctionIdentifier } from '../../../state/orderPlacement/reducer'
-import { getTokenDisplay } from '../../../utils'
+import { getTokenDisplay, isTokenXDAI } from '../../../utils'
 import { Button } from '../../buttons/Button'
 import { ButtonAnchor } from '../../buttons/ButtonAnchor'
 import { ButtonType } from '../../buttons/buttonStylingTypes'
@@ -151,33 +151,35 @@ const Claimer: React.FC<Props> = (props) => {
                       }}
                     />
                     <Text>{biddingTokenDisplay != 'XDAI' ? biddingTokenDisplay : `WXDAI`}</Text>
-                    <span
-                      className={`tooltipComponent`}
-                      data-for={'wrap_button'}
-                      data-html={true}
-                      data-multiline={true}
-                      data-tip={`Unwrap ${derivedAuctionInfo?.biddingToken.symbol} on Honeyswap`}
-                    >
-                      <ReactTooltip
-                        arrowColor={'#001429'}
-                        backgroundColor={'#001429'}
-                        border
-                        borderColor={'#174172'}
-                        className="customTooltip"
-                        delayHide={50}
-                        delayShow={250}
-                        effect="solid"
-                        id={'wrap_button'}
-                        textColor="#fff"
-                      />
-                      <ButtonWrap
-                        buttonType={ButtonType.primaryInverted}
-                        href={`https://app.honeyswap.org/#/swap?outputCurrency=${derivedAuctionInfo?.biddingToken.address}`}
-                        target="_blank"
+                    {isTokenXDAI(derivedAuctionInfo?.biddingToken.address, chainId) ? (
+                      <span
+                        className={`tooltipComponent`}
+                        data-for={'wrap_button'}
+                        data-html={true}
+                        data-multiline={true}
+                        data-tip={`Unwrap ${derivedAuctionInfo?.biddingToken.symbol} on Honeyswap. Do it after you claimed your WXDAI`}
                       >
-                        Unwrap
-                      </ButtonWrap>
-                    </span>
+                        <ReactTooltip
+                          arrowColor={'#001429'}
+                          backgroundColor={'#001429'}
+                          border
+                          borderColor={'#174172'}
+                          className="customTooltip"
+                          delayHide={50}
+                          delayShow={250}
+                          effect="solid"
+                          id={'wrap_button'}
+                          textColor="#fff"
+                        />
+                        <ButtonWrap
+                          buttonType={ButtonType.primaryInverted}
+                          href={`https://app.honeyswap.org/#/swap?inputCurrency=${derivedAuctionInfo?.biddingToken.address}`}
+                          target="_blank"
+                        >
+                          Unwrap
+                        </ButtonWrap>
+                      </span>
+                    ) : null}
                   </>
                 ) : (
                   '-'

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -365,7 +365,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
                       href={`https://app.honeyswap.org/#/swap?inputCurrency=${biddingToken.address}`}
                       target="_blank"
                     >
-                      Unwrap
+                      Unwrap WXDAI
                     </ButtonWrap>
                   </span>
                 )}

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -22,7 +22,7 @@ import { AuctionIdentifier } from '../../../state/orderPlacement/reducer'
 import { useOrderState } from '../../../state/orders/hooks'
 import { OrderState } from '../../../state/orders/reducer'
 import { useTokenBalancesTreatWETHAsETHonXDAI } from '../../../state/wallet/hooks'
-import { ChainId, EASY_AUCTION_NETWORKS, getTokenDisplay } from '../../../utils'
+import { ChainId, EASY_AUCTION_NETWORKS, getTokenDisplay, isTokenXDAI } from '../../../utils'
 import { getChainName } from '../../../utils/tools'
 import { Button } from '../../buttons/Button'
 import { ButtonAnchor } from '../../buttons/ButtonAnchor'
@@ -337,35 +337,38 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
               <Balance>
                 Your Balance: <Total>{`${balanceString} `}</Total>
               </Balance>
-              {chainId === chainIdFromWeb3 && account && biddingToken && biddingToken.address && (
-                <span
-                  className={`tooltipComponent`}
-                  data-for={'wrap_button'}
-                  data-html={true}
-                  data-multiline={true}
-                  data-tip={`Wrap ${biddingToken.symbol} on Honeyswap`}
-                >
-                  <ReactTooltip
-                    arrowColor={'#001429'}
-                    backgroundColor={'#001429'}
-                    border
-                    borderColor={'#174172'}
-                    className="customTooltip"
-                    delayHide={50}
-                    delayShow={250}
-                    effect="solid"
-                    id={'wrap_button'}
-                    textColor="#fff"
-                  />
-                  <ButtonWrap
-                    buttonType={ButtonType.primaryInverted}
-                    href={`https://app.honeyswap.org/#/swap?inputCurrency=${biddingToken.address}`}
-                    target="_blank"
+              {isTokenXDAI(biddingToken.address, chainId) &&
+                account &&
+                biddingToken &&
+                biddingToken.address && (
+                  <span
+                    className={`tooltipComponent`}
+                    data-for={'wrap_button'}
+                    data-html={true}
+                    data-multiline={true}
+                    data-tip={`Unwrap WXDAI on Honeyswap`}
                   >
-                    Wrap
-                  </ButtonWrap>
-                </span>
-              )}
+                    <ReactTooltip
+                      arrowColor={'#001429'}
+                      backgroundColor={'#001429'}
+                      border
+                      borderColor={'#174172'}
+                      className="customTooltip"
+                      delayHide={50}
+                      delayShow={250}
+                      effect="solid"
+                      id={'wrap_button'}
+                      textColor="#fff"
+                    />
+                    <ButtonWrap
+                      buttonType={ButtonType.primaryInverted}
+                      href={`https://app.honeyswap.org/#/swap?inputCurrency=${biddingToken.address}`}
+                      target="_blank"
+                    >
+                      Wrap
+                    </ButtonWrap>
+                  </span>
+                )}
             </BalanceWrapper>
             <CurrencyInputPanel
               chainId={chainId}

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -346,7 +346,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
                     data-for={'wrap_button'}
                     data-html={true}
                     data-multiline={true}
-                    data-tip={`Unwrap WXDAI on Honeyswap`}
+                    data-tip={`Unwrap WXDAI to XDAI on Honeyswap`}
                   >
                     <ReactTooltip
                       arrowColor={'#001429'}
@@ -365,7 +365,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
                       href={`https://app.honeyswap.org/#/swap?inputCurrency=${biddingToken.address}`}
                       target="_blank"
                     >
-                      Wrap
+                      Unwrap
                     </ButtonWrap>
                   </span>
                 )}

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { Fraction, TokenAmount } from 'uniswap-xdai-sdk'
 
+import ReactTooltip from 'react-tooltip'
+
 import { useActiveWeb3React } from '../../../hooks'
 import { ApprovalState, useApproveCallback } from '../../../hooks/useApproveCallback'
 import { useAuctionDetails } from '../../../hooks/useAuctionDetails'
@@ -23,6 +25,7 @@ import { useTokenBalancesTreatWETHAsETHonXDAI } from '../../../state/wallet/hook
 import { ChainId, EASY_AUCTION_NETWORKS, getTokenDisplay } from '../../../utils'
 import { getChainName } from '../../../utils/tools'
 import { Button } from '../../buttons/Button'
+import { ButtonAnchor } from '../../buttons/ButtonAnchor'
 import { ButtonType } from '../../buttons/buttonStylingTypes'
 import { InlineLoading } from '../../common/InlineLoading'
 import { SpinnerSize } from '../../common/Spinner'
@@ -37,7 +40,6 @@ import SwapModalFooter from '../../modals/common/PlaceOrderModalFooter'
 import { BaseCard } from '../../pureStyledComponents/BaseCard'
 import { EmptyContentText } from '../../pureStyledComponents/EmptyContent'
 import { ErrorRow, ErrorText, ErrorWrapper } from '../../pureStyledComponents/Error'
-import TokenLogo from '../../token/TokenLogo'
 
 const Wrapper = styled(BaseCard)`
   max-width: 100%;
@@ -133,6 +135,14 @@ const EmptyContentTextSmall = styled(EmptyContentText)`
   font-size: 16px;
   font-weight: 400;
   margin-top: 0;
+`
+
+const ButtonWrap = styled(ButtonAnchor)`
+  border-radius: 4px;
+  font-size: 12px;
+  height: 20px;
+  margin: -2px 6px 0 0;
+  padding: 0 5px;
 `
 
 interface OrderPlacementProps {
@@ -328,13 +338,33 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
                 Your Balance: <Total>{`${balanceString} `}</Total>
               </Balance>
               {chainId === chainIdFromWeb3 && account && biddingToken && biddingToken.address && (
-                <TokenLogo
-                  size={'22px'}
-                  token={{
-                    address: biddingToken.address,
-                    symbol: getTokenDisplay(biddingToken, chainId),
-                  }}
-                />
+                <span
+                  className={`tooltipComponent`}
+                  data-for={'wrap_button'}
+                  data-html={true}
+                  data-multiline={true}
+                  data-tip={`Wrap ${biddingToken.symbol} on Honeyswap`}
+                >
+                  <ReactTooltip
+                    arrowColor={'#001429'}
+                    backgroundColor={'#001429'}
+                    border
+                    borderColor={'#174172'}
+                    className="customTooltip"
+                    delayHide={50}
+                    delayShow={250}
+                    effect="solid"
+                    id={'wrap_button'}
+                    textColor="#fff"
+                  />
+                  <ButtonWrap
+                    buttonType={ButtonType.primaryInverted}
+                    href={`https://app.honeyswap.org/#/swap?inputCurrency=${biddingToken.address}`}
+                    target="_blank"
+                  >
+                    Wrap
+                  </ButtonWrap>
+                </span>
               )}
             </BalanceWrapper>
             <CurrencyInputPanel


### PR DESCRIPTION
I'm not completely sure about what's needed here, but hopefully this is OK. It's obviously still missing some logic, which I think @josojo will implement.

It should look more or less like these:

![Screen Shot 2021-05-06 at 14 28 43](https://user-images.githubusercontent.com/4015436/117342454-a7894880-ae79-11eb-9e1f-de5fd0264414.png)
![Screen Shot 2021-05-06 at 14 28 57](https://user-images.githubusercontent.com/4015436/117342468-aa843900-ae79-11eb-939f-88eb6f492ec7.png)
![Screen Shot 2021-05-06 at 14 29 10](https://user-images.githubusercontent.com/4015436/117342475-abb56600-ae79-11eb-866b-f6654af938c1.png)
![Screen Shot 2021-05-06 at 14 29 24](https://user-images.githubusercontent.com/4015436/117342479-ac4dfc80-ae79-11eb-9a44-7898fd3b2ad1.png)

We could create a better workflow for this later, maybe similar to what we implemented on https://github.com/gnosis/conditional-tokens-explorer for Wrapping / Unwrapping (which looks or looked like these other images)

![09- CTEAF Positions](https://user-images.githubusercontent.com/4015436/117342739-f1722e80-ae79-11eb-873f-270db91bd450.png)
![16- CTEAF Wrap](https://user-images.githubusercontent.com/4015436/117342757-f505b580-ae79-11eb-94ba-fb370b53b6a0.png)
![17- CTEAF Unwrap](https://user-images.githubusercontent.com/4015436/117342762-f636e280-ae79-11eb-857f-305b8150fe07.png)
