### PR TITLE
Add update AuctionState after order cancellation time expires

### DIFF
--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -367,17 +367,28 @@ export function useDerivedAuctionInfo(
 
     const getCurrentState = () => deriveAuctionState(auctionDetails, clearingPriceInfo).auctionState
     setAuctionState(getCurrentState())
-    const timeLeft = calculateTimeLeft(auctionDetails.endTimeTimestamp)
+    const timeLeftEndAuction = calculateTimeLeft(auctionDetails.endTimeTimestamp)
+    const timeLeftCancellationOrder = calculateTimeLeft(
+      auctionDetails.orderCancellationEndDate as number,
+    )
 
-    if (timeLeft < 0) {
-      return
+    const updateStatusWhenTimeIsUp = (remainingAuctionTimes: Array<number>) => {
+      const timersId = remainingAuctionTimes
+        .map((timeLeft) => {
+          if (timeLeft < 0) {
+            return
+          }
+          return setTimeout(() => {
+            setAuctionState(getCurrentState())
+          }, timeLeft * 1000)
+        })
+        .filter((timeId) => typeof timeId !== 'undefined')
+      return timersId
     }
-    const timerId = setTimeout(() => {
-      setAuctionState(getCurrentState())
-    }, timeLeft * 1000)
+    const timerEventsId = updateStatusWhenTimeIsUp([timeLeftCancellationOrder, timeLeftEndAuction])
 
     return () => {
-      clearTimeout(timerId)
+      timerEventsId.map((timerId) => clearTimeout(timerId))
     }
   }, [auctionDetails, clearingPriceInfo, noAuctionData])
 

--- a/src/state/orderPlacement/hooks.ts
+++ b/src/state/orderPlacement/hooks.ts
@@ -382,7 +382,7 @@ export function useDerivedAuctionInfo(
             setAuctionState(getCurrentState())
           }, timeLeft * 1000)
         })
-        .filter((timeId) => typeof timeId !== 'undefined')
+        .filter(isTimeout)
       return timersId
     }
     const timerEventsId = updateStatusWhenTimeIsUp([timeLeftCancellationOrder, timeLeftEndAuction])

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,3 +4,7 @@ declare module '*.woff2'
 declare module '*.otf'
 declare module './theme'
 declare module "*.md"
+
+function isTimeout(timeId: NodeJS.Timeout | undefined): timeId is NodeJS.Timeout {
+    return typeof timeId !== 'undefined'
+}


### PR DESCRIPTION
closes: #507 

When auction `orderCancellationtime` expires, The `auctionState` is not updated so the "cancel" **button remains enable**.

Update a `useEffect` that updates the `auctionState` when the `endTime` expires

⚠️ it seems questionable to me whether to use an **action** through redux, if this event needs to be heard in another component.
- Enviroment
auctionId: 20
chainId: 4
