### PR TITLE
Don't throw if api is not available

### DIFF
--- a/src/api/AdditionalServicesApi.ts
+++ b/src/api/AdditionalServicesApi.ts
@@ -308,7 +308,7 @@ export class AdditionalServicesApiImpl implements AdditionalServicesApi {
           if (!res.value.ok) {
             // backend returns {"message":"invalid url query"}
             // for bad requests
-            throw await res.value.json()
+            logger.error('Error getting most interesting auction details: ', res.value.json())
           }
           allInterestingAuctions.push(await res.value.json())
         }

--- a/src/api/AdditionalServicesApi.ts
+++ b/src/api/AdditionalServicesApi.ts
@@ -212,7 +212,10 @@ export class AdditionalServicesApiImpl implements AdditionalServicesApi {
           if (!res.value.ok) {
             // backend returns {"message":"invalid url query"}
             // for bad requests
-            throw await res.value.json()
+            logger.error(
+              'Error getting all auction details with user participation: ',
+              res.value.json(),
+            )
           }
           allAuctions.push(await res.value.json())
         }

--- a/src/api/AdditionalServicesApi.ts
+++ b/src/api/AdditionalServicesApi.ts
@@ -216,8 +216,9 @@ export class AdditionalServicesApiImpl implements AdditionalServicesApi {
               'Error getting all auction details with user participation: ',
               res.value.json(),
             )
+          } else {
+            allAuctions.push(await res.value.json())
           }
-          allAuctions.push(await res.value.json())
         }
       }
       return allAuctions.flat()
@@ -245,15 +246,24 @@ export class AdditionalServicesApiImpl implements AdditionalServicesApi {
 
         promises.push(fetch(url))
       }
-      const results = await Promise.all(promises)
+      const results = await Promise.allSettled(promises)
       const allAuctions = []
       for (const res of results) {
-        if (!res.ok) {
-          // backend returns {"message":"invalid url query"}
-          // for bad requests
-          throw await res.json()
+        if (res.status === 'rejected') {
+          logger.error('Error getting all auction details without user participation: ', res.reason)
         }
-        allAuctions.push(await res.json())
+        if (res.status === 'fulfilled') {
+          if (!res.value.ok) {
+            // backend returns {"message":"invalid url query"}
+            // for bad requests
+            logger.error(
+              'Error getting all auction details without user participation: ',
+              res.value.json(),
+            )
+          } else {
+            allAuctions.push(await res.value.json())
+          }
+        }
       }
       return allAuctions.flat()
     } catch (error) {
@@ -312,8 +322,9 @@ export class AdditionalServicesApiImpl implements AdditionalServicesApi {
             // backend returns {"message":"invalid url query"}
             // for bad requests
             logger.error('Error getting most interesting auction details: ', res.value.json())
+          } else {
+            allInterestingAuctions.push(await res.value.json())
           }
-          allInterestingAuctions.push(await res.value.json())
         }
       }
 


### PR DESCRIPTION
Currently, the auctions are not loaded in dev in case one API is rebooting and then everything is blocked. This PR fixes it