### PR TITLE
Add PENDING ClaimState after claiming

### DIFF
--- a/src/components/auction/Claimer/index.tsx
+++ b/src/components/auction/Claimer/index.tsx
@@ -4,7 +4,11 @@ import styled from 'styled-components'
 import ReactTooltip from 'react-tooltip'
 
 import { useActiveWeb3React } from '../../../hooks'
-import { useClaimOrderCallback, useGetAuctionProceeds } from '../../../hooks/useClaimOrderCallback'
+import {
+  ClaimState,
+  useClaimOrderCallback,
+  useGetAuctionProceeds,
+} from '../../../hooks/useClaimOrderCallback'
 import { useWalletModalToggle } from '../../../state/application/hooks'
 import { DerivedAuctionInfo, useDerivedClaimInfo } from '../../../state/orderPlacement/hooks'
 import { AuctionIdentifier } from '../../../state/orderPlacement/reducer'
@@ -87,6 +91,7 @@ const Claimer: React.FC<Props> = (props) => {
   const [pendingConfirmation, setPendingConfirmation] = useState<boolean>(true)
   const [txHash, setTxHash] = useState<string>('')
   const pendingText = `Claiming Funds`
+  const [claimStatus, claimOrderCallback] = useClaimOrderCallback(auctionIdentifier)
   const { error, isLoading: isDerivedClaimInfoLoading } = useDerivedClaimInfo(auctionIdentifier)
   const isValid = !error
   const toggleWalletModal = useWalletModalToggle()
@@ -97,7 +102,6 @@ const Claimer: React.FC<Props> = (props) => {
   )
 
   const resetModal = () => setPendingConfirmation(true)
-  const claimOrderCallback = useClaimOrderCallback(auctionIdentifier)
 
   const onClaimOrder = () =>
     claimOrderCallback()
@@ -129,8 +133,13 @@ const Claimer: React.FC<Props> = (props) => {
   )
 
   const isClaimButtonDisabled = useMemo(
-    () => !isValid || showConfirm || isLoading || userConfirmedTx,
-    [isValid, showConfirm, isLoading, userConfirmedTx],
+    () =>
+      !isValid ||
+      showConfirm ||
+      isLoading ||
+      userConfirmedTx ||
+      claimStatus != ClaimState.NOT_CLAIMED,
+    [isValid, showConfirm, isLoading, userConfirmedTx, claimStatus],
   )
 
   return (
@@ -229,7 +238,7 @@ const Claimer: React.FC<Props> = (props) => {
                 onClaimOrder()
               }}
             >
-              Claim
+              {claimStatus === ClaimState.PENDING ? `Claiming ` : `Claim`}
             </ActionButton>
           )}
           <ClaimConfirmationModal

--- a/src/hooks/useClaimOrderCallback.ts
+++ b/src/hooks/useClaimOrderCallback.ts
@@ -202,17 +202,17 @@ export const useClaimOrderCallback = (
 
   const claimableOrders = claimInfo?.sellOrdersFormUser
   const userHasAvailableClaim = useUserHasAvailableClaim(auctionIdentifier, claimableOrders)
-  const pendingApproval = useHasPendingClaim(auctionIdentifier.auctionId, account)
+  const pendingClaim = useHasPendingClaim(auctionIdentifier.auctionId, account)
 
   const claimStatus = useMemo(() => {
     if (!claimableOrders) return ClaimState.UNKNOWN
 
     return userHasAvailableClaim
-      ? pendingApproval
+      ? pendingClaim
         ? ClaimState.PENDING
         : ClaimState.NOT_CLAIMED
       : ClaimState.CLAIMED
-  }, [claimableOrders, pendingApproval, userHasAvailableClaim])
+  }, [claimableOrders, pendingClaim, userHasAvailableClaim])
 
   return [claimStatus, claimCallback]
 }

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -144,7 +144,11 @@ export function useHasPendingClaim(auctionId?: number, from?: string | null): bo
         if (tx.receipt) {
           return false
         } else {
-          return `Claiming tokens auction-${auctionId}` === tx.summary && isTransactionRecent(tx)
+          return (
+            tx.from === from &&
+            `Claiming tokens auction-${auctionId}` === tx.summary &&
+            isTransactionRecent(tx)
+          )
         }
       })
     )

--- a/src/state/transactions/hooks.tsx
+++ b/src/state/transactions/hooks.tsx
@@ -129,3 +129,24 @@ export function useHasPendingApproval(tokenAddress?: string, spender?: string): 
   }
   return hasPendingApproval
 }
+
+// returns whether a account has a pending claim transaction
+export function useHasPendingClaim(auctionId?: number, from?: string | null): boolean {
+  const allTransactions = useAllTransactions()
+
+  return useMemo(() => {
+    return (
+      typeof auctionId === 'number' &&
+      typeof from === 'string' &&
+      Object.keys(allTransactions).some((hash) => {
+        const tx = allTransactions[hash]
+        if (!tx) return false
+        if (tx.receipt) {
+          return false
+        } else {
+          return `Claiming tokens auction-${auctionId}` === tx.summary && isTransactionRecent(tx)
+        }
+      })
+    )
+  }, [allTransactions, auctionId, from])
+}


### PR DESCRIPTION
closes: #560 

Added `ClaimState`, specifically PENDING status after claim txs.
![Selection_283](https://user-images.githubusercontent.com/4270166/118568002-3dac5100-b74d-11eb-97ff-369b19486115.png)

**Problem:** 
after claiming an auction the user can press the **claim button again**, without waiting for the transaction to be mined.

**Proposal:**
Add transaction detail [in the summary](https://github.com/gnosis/ido-ux/blob/8d0f81033341b12c7d6d7603889033590288a2b1/src/state/transactions/hooks.tsx#L147) to identify **recent unconfirmed transactions** 

⚠️ this solution will not work if i open the auction from another client

**Enviroment:**
ChainId: 4
AuctionId: 89, 90