### PR TITLE
tokenDisplay depending on chainId from url

### DIFF
--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -376,6 +376,7 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
               }}
             />
             <PriceInputPanel
+              chainId={chainId}
               info={priceInfo}
               invertPrices={showPriceInverted}
               onInvertPrices={onInvertPrices}

--- a/src/components/form/PriceInputPanel/index.tsx
+++ b/src/components/form/PriceInputPanel/index.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import { Token } from 'uniswap-xdai-sdk'
 
-import { useActiveWeb3React } from '../../../hooks'
 import { getTokenDisplay } from '../../../utils'
 import { Tooltip } from '../../common/Tooltip'
 import { InvertIcon } from '../../icons/InvertIcon'
@@ -41,6 +40,7 @@ const InvertButton = styled(FieldRowLineButton)`
 `
 
 interface Props {
+  chainId: number
   info?: FieldRowInfoProps
   invertPrices: boolean
   onInvertPrices: () => void
@@ -51,6 +51,7 @@ interface Props {
 
 const PriceInputPanel = (props: Props) => {
   const {
+    chainId,
     info,
     invertPrices,
     onInvertPrices,
@@ -60,8 +61,6 @@ const PriceInputPanel = (props: Props) => {
     ...restProps
   } = props
   const error = info?.type === InfoType.error
-
-  const { chainId } = useActiveWeb3React()
 
   const { auctioningTokenDisplay, biddingTokenDisplay } = useMemo(() => {
     if (tokens && chainId && tokens.auctioningToken && tokens.biddingToken) {


### PR DESCRIPTION
I realized that it's better to depend on the chainID from URL instead of the web3 session, in order to always show the correct tokenSymbol