### PR TITLE
Handling app crashing when walletconnect is using another supported network

### DIFF
--- a/src/components/modals/WalletModal/index.tsx
+++ b/src/components/modals/WalletModal/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { URI_AVAILABLE } from '@anxolin/walletconnect-connector'
+import { URI_AVAILABLE, WalletConnectConnector } from '@anxolin/walletconnect-connector'
 import { AbstractConnector } from '@web3-react/abstract-connector'
 import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core'
 import ReactGA from 'react-ga'
@@ -188,7 +188,11 @@ const WalletModal: React.FC = () => {
       }
     } catch (error) {
       if (error instanceof UnsupportedChainIdError) {
-        activate(connector) // a little janky...can't use setError because the connector isn't set
+        let c = connector
+        if (c[chainId] instanceof WalletConnectConnector) {
+          c = c[chainId]
+        }
+        activate(c) // a little janky...can't use setError because the connector isn't set
       } else {
         setPendingError(true)
       }

--- a/src/components/modals/WalletModal/index.tsx
+++ b/src/components/modals/WalletModal/index.tsx
@@ -188,11 +188,10 @@ const WalletModal: React.FC = () => {
       }
     } catch (error) {
       if (error instanceof UnsupportedChainIdError) {
-        let c = connector
-        if (c[chainId] instanceof WalletConnectConnector) {
-          c = c[chainId]
-        }
-        activate(c) // a little janky...can't use setError because the connector isn't set
+        // a little janky...can't use setError because the connector isn't set
+        activate(
+          connector[chainId] instanceof WalletConnectConnector ? connector[chainId] : connector,
+        )
       } else {
         setPendingError(true)
       }

--- a/src/components/modals/common/PendingView/index.tsx
+++ b/src/components/modals/common/PendingView/index.tsx
@@ -25,7 +25,6 @@ interface Props {
   error?: boolean
   setPendingError: (error: boolean) => void
   tryActivation: (connector: AbstractConnector) => void
-  uri?: string
 }
 
 const PendingView: React.FC<Props> = (props) => {


### PR DESCRIPTION
closes: #658 

When I connect via `walletconnect` from a network not supported by the specified the app is crash.

- [x] Fixed the app crashed when the user connect via `walletconnet` through **from the Auctions** `/overview` page, where it is possible to connect from different supported networks.

