### PR TITLE
adding kyc link and  connect button

### DIFF
--- a/src/assets/links/kycLinks.json
+++ b/src/assets/links/kycLinks.json
@@ -1,0 +1,3 @@
+{
+"0x0C033bb39e67eB598D399C06A8A519498dA1Cec9": "https://qualify.swarm.markets"
+}

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -49,6 +49,8 @@ const LinkCSS = css`
   color: ${({ theme }) => theme.text1};
   text-decoration: none;
   transition: color 0.05s linear;
+  font-size: 1.5em;
+  font-weight: bold;
 
   &:hover {
     color: ${({ theme }) => theme.primary2};
@@ -347,28 +349,27 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
     <>
       <Wrapper>
         {auctionInfoLoading && <InlineLoading size={SpinnerSize.small} />}
-        {!auctionInfoLoading && isPrivate && !signatureAvailable && account == null && (
-          <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>
-        )}
-        {!auctionInfoLoading && isPrivate && !signatureAvailable && account != null && (
-          <PrivateWrapper>
-            <LockBig />
-            <TextBig>Private auction</TextBig>
-            <EmptyContentTextNoMargin>
-              You need to get allowed to participate.
-            </EmptyContentTextNoMargin>
-            <EmptyContentTextSmall>
-              {linkForKYC ? (
-                <ExternalLink href={linkForKYC}>
-                  <h2>Get Allowed ↗</h2>
-                </ExternalLink>
-              ) : (
-                <EmptyContentTextSmall>
-                  Ask the auctioneer to get allow-listed.
-                </EmptyContentTextSmall>
-              )}{' '}
-            </EmptyContentTextSmall>
-          </PrivateWrapper>
+        {!auctionInfoLoading && isPrivate && !signatureAvailable && (
+          <>
+            <PrivateWrapper>
+              <LockBig />
+              <TextBig>Private auction</TextBig>
+              <EmptyContentTextNoMargin>
+                You need to get allowed to participate.
+              </EmptyContentTextNoMargin>
+            </PrivateWrapper>
+            {account == null ? (
+              <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>
+            ) : (
+              <EmptyContentTextSmall>
+                {linkForKYC ? (
+                  <ExternalLink href={linkForKYC}>Get Allowed ↗</ExternalLink>
+                ) : (
+                  <>Ask the auctioneer to get allow-listed.</>
+                )}{' '}
+              </EmptyContentTextSmall>
+            )}
+          </>
         )}
         {!auctionInfoLoading && (!isPrivate || signatureAvailable) && (
           <>

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Fraction, TokenAmount } from 'uniswap-xdai-sdk'
 
+import kycLinks from '../../../assets/links/kycLinks.json'
 import { NUMBER_OF_DIGITS_FOR_INVERSION } from '../../../constants/config'
 import { useActiveWeb3React } from '../../../hooks'
 import { ApprovalState, useApproveCallback } from '../../../hooks/useApproveCallback'
@@ -43,6 +44,20 @@ import SwapModalFooter from '../../modals/common/PlaceOrderModalFooter'
 import { BaseCard } from '../../pureStyledComponents/BaseCard'
 import { EmptyContentText } from '../../pureStyledComponents/EmptyContent'
 import { InfoType } from '../../pureStyledComponents/FieldRow'
+
+const LinkCSS = css`
+  color: ${({ theme }) => theme.text1};
+  text-decoration: none;
+  transition: color 0.05s linear;
+
+  &:hover {
+    color: ${({ theme }) => theme.primary2};
+  }
+`
+
+const ExternalLink = styled.a`
+  ${LinkCSS}
+`
 
 const Wrapper = styled(BaseCard)`
   max-width: 100%;
@@ -326,18 +341,33 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
     !!account &&
     !!biddingToken.address
 
+  const auctioningTokenAddress = auctioningToken && auctioningToken?.address
+  const linkForKYC = auctioningTokenAddress ? kycLinks[auctioningTokenAddress] : null
   return (
     <>
       <Wrapper>
         {auctionInfoLoading && <InlineLoading size={SpinnerSize.small} />}
-        {!auctionInfoLoading && isPrivate && !signatureAvailable && (
+        {!auctionInfoLoading && isPrivate && !signatureAvailable && account == null && (
+          <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>
+        )}
+        {!auctionInfoLoading && isPrivate && !signatureAvailable && account != null && (
           <PrivateWrapper>
             <LockBig />
             <TextBig>Private auction</TextBig>
             <EmptyContentTextNoMargin>
-              You are not allowed to place an order.
+              You need to get allowed to participate.
             </EmptyContentTextNoMargin>
-            <EmptyContentTextSmall>Ask the auctioneer to get allow-listed.</EmptyContentTextSmall>
+            <EmptyContentTextSmall>
+              {linkForKYC ? (
+                <ExternalLink href={linkForKYC}>
+                  <h2>Get Allowed ↗</h2>
+                </ExternalLink>
+              ) : (
+                <EmptyContentTextSmall>
+                  Ask the auctioneer to get allow-listed.
+                </EmptyContentTextSmall>
+              )}{' '}
+            </EmptyContentTextSmall>
           </PrivateWrapper>
         )}
         {!auctionInfoLoading && (!isPrivate || signatureAvailable) && (

--- a/src/components/auction/OrderPlacement/index.tsx
+++ b/src/components/auction/OrderPlacement/index.tsx
@@ -354,9 +354,11 @@ const OrderPlacement: React.FC<OrderPlacementProps> = (props) => {
             <PrivateWrapper>
               <LockBig />
               <TextBig>Private auction</TextBig>
-              <EmptyContentTextNoMargin>
-                You need to get allowed to participate.
-              </EmptyContentTextNoMargin>
+              {account !== null && (
+                <EmptyContentTextNoMargin>
+                  You need to get allowed to participate.
+                </EmptyContentTextNoMargin>
+              )}
             </PrivateWrapper>
             {account == null ? (
               <ActionButton onClick={toggleWalletModal}>Connect Wallet</ActionButton>

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "strict": true,
     "noImplicitAny": true,
+    "resolveJsonModule": true,
     "alwaysStrict": true,
     "strictNullChecks": true,
     "noImplicitReturns": true,

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "strict": true,
     "noImplicitAny": true,
-    "resolveJsonModule": true,
     "alwaysStrict": true,
     "strictNullChecks": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
This adds the kyc link that can be maintained for each auctioning token

the KYC json list should be fetched from this github repo, instead of the build, but for reviewing the PR I am pulling it via internal reference.

If the account is not yet connected, currently the interface shows that the user is not allowlisted, which is confusing. I changed that behaviour as well and show the user the connect button.

@henrypalacios any proposal for improvements are highly welcome